### PR TITLE
Add helper methods to access resources that could be lists

### DIFF
--- a/src/rod/link.py
+++ b/src/rod/link.py
@@ -105,3 +105,25 @@ class Link(Element):
             serialize=Element.serialize_bool, deserialize=Element.deserialize_bool
         ),
     )
+
+    def visuals(self) -> List[Visual]:
+
+        if self.visual is None:
+            return []
+
+        if isinstance(self.visual, Visual):
+            return [self.visual]
+
+        assert isinstance(self.visual, list), type(self.visual)
+        return self.visual
+
+    def collisions(self) -> List[Collision]:
+
+        if self.collision is None:
+            return []
+
+        if isinstance(self.collision, Collision):
+            return [self.collision]
+
+        assert isinstance(self.collision, list), type(self.collision)
+        return self.collision

--- a/src/rod/model.py
+++ b/src/rod/model.py
@@ -59,3 +59,47 @@ class Model(Element):
     link: Optional[Union[Link, List[Link]]] = dataclasses.field(default=None)
 
     joint: Optional[Union[Joint, List[Joint]]] = dataclasses.field(default=None)
+
+    def models(self) -> List["Model"]:
+
+        if self.model is None:
+            return []
+
+        if isinstance(self.model, Model):
+            return [self.model]
+
+        assert isinstance(self.model, list)
+        return self.model
+
+    def frames(self) -> List[Frame]:
+
+        if self.frame is None:
+            return []
+
+        if isinstance(self.frame, Frame):
+            return [self.frame]
+
+        assert isinstance(self.frame, list)
+        return self.frame
+
+    def links(self) -> List[Link]:
+
+        if self.link is None:
+            return []
+
+        if isinstance(self.link, Link):
+            return [self.link]
+
+        assert isinstance(self.link, list), type(self.link)
+        return self.link
+
+    def joints(self) -> List[Joint]:
+
+        if self.joint is None:
+            return []
+
+        if isinstance(self.joint, Joint):
+            return [self.joint]
+
+        assert isinstance(self.joint, list), type(self.joint)
+        return self.joint

--- a/src/rod/sdf.py
+++ b/src/rod/sdf.py
@@ -25,6 +25,28 @@ class Sdf(Element):
 
     model: Optional[Union[Model, List[Model]]] = dataclasses.field(default=None)
 
+    def worlds(self) -> List[World]:
+
+        if self.world is None:
+            return []
+
+        if isinstance(self.world, World):
+            return [self.world]
+
+        assert isinstance(self.world, list), type(self.world)
+        return self.world
+
+    def models(self) -> List[Model]:
+
+        if self.model is None:
+            return []
+
+        if isinstance(self.model, Model):
+            return [self.model]
+
+        assert isinstance(self.model, list), type(self.model)
+        return self.model
+
     @staticmethod
     def load(sdf: Union[pathlib.Path, str], is_urdf: Optional[bool] = None) -> "Sdf":
         """


### PR DESCRIPTION
There are a bunch of elements that could be parsed either as single objects or lists. This complicates downstream logic since an instance check should be performed. This PR adds new helpers that always return a list even in case of single objects.