### PR TITLE
Add utilities to handle SDF models as a directed trees

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     mashumaro
     numpy
     packaging
+    pptree
     scipy
     xmltodict
 

--- a/src/rod/kinematics/__init__.py
+++ b/src/rod/kinematics/__init__.py
@@ -1,0 +1,1 @@
+from . import kinematic_tree, tree_transforms

--- a/src/rod/kinematics/kinematic_tree.py
+++ b/src/rod/kinematics/kinematic_tree.py
@@ -1,0 +1,327 @@
+import copy
+import dataclasses
+import functools
+from typing import Dict, List, Sequence, Tuple, Union
+
+import numpy as np
+
+import rod
+from rod import logging
+from rod.tree import DirectedTree, DirectedTreeNode, TreeEdge, TreeFrame
+
+
+@dataclasses.dataclass(frozen=True)
+class KinematicTree(DirectedTree):
+
+    model: rod.Model
+
+    joints: List[TreeEdge] = dataclasses.field(default_factory=list)
+    frames: List[TreeFrame] = dataclasses.field(default_factory=list)
+
+    def __post_init__(self):
+
+        # Initialize base class
+        super().__post_init__()
+
+        # Ge the index of the last link
+        last_node_idx = list(iter(self))[-1].index
+
+        # Assign frames indices. The frames indexing continues the link indexing.
+        for frame_idx, node in enumerate(self.frames):
+            node.index = last_node_idx + 1 + frame_idx
+
+        # Assign joint indices. The joint index matches the index of its child link.
+        for joint in self.joints:
+            joint.index = self.links_dict[joint.child.name()].index
+
+        # Order the lists containing joints and frames
+        self.joints.sort(key=lambda j: j.index)
+        self.frames.sort(key=lambda f: f.index)
+
+    def link_names(self) -> List[str]:
+        return [node.name() for node in self]
+
+    def frame_names(self) -> List[str]:
+        return [frame.name() for frame in self.frames]
+
+    def joint_names(self) -> List[str]:
+        return [joint.name() for joint in self.joints]
+
+    @staticmethod
+    def build(model: rod.Model, is_top_level: bool = True) -> "KinematicTree":
+
+        logging.debug(msg=f"Building kinematic tree of model '{model.name}'")
+
+        if model.model is not None:
+            msg = "Model composition is not yet supported. Ignoring all sub-models."
+            logging.warning(msg=msg)
+
+        # Copy the model and make reference frames explicit, i.e. add the pose element
+        # to all models, links, joints, frames.
+        # In this build method, we don't require any specific FrameConvention since
+        # converting a tree to a new convention would need to build the tree first.
+        model = copy.deepcopy(model)
+        model.resolve_frames(is_top_level=is_top_level, explicit_frames=True)
+
+        # Generally speaking, a rod.Model describes a DAG (directed acyclic graph).
+        # Since we do not yet support closed loops / parallel kinematic structures,
+        # we can restrict the family of supported rod.Models to those describing
+        # a tree, i.e. a DAG whose nodes have a single parent.
+        # The links of the model are the nodes of the tree, and joints its edges.
+        # The root of the tree is defined by the canonical link of the model.
+        # The model could also define additional elements called frames that are
+        # pseudo-nodes attached to either a node or another pseudo-node (another frame).
+
+        # In our tree, links are the nodes and joints the edges.
+        # Create a dict mapping link names to tree nodes, for easy retrieval.
+        nodes_links_dict: Dict[str, DirectedTreeNode] = {
+            # Add one node for each link of the model
+            **{link.name: DirectedTreeNode(_source=link) for link in model.links()},
+            # Add special world node, that will become a frame later
+            TreeFrame.WORLD: DirectedTreeNode(
+                _source=rod.Link(
+                    name=TreeFrame.WORLD,
+                    pose=rod.Pose(relative_to=TreeFrame.WORLD),
+                )
+            ),
+        }
+
+        # Get the canonical link of the model.
+        # The canonical link defines the implicit coordinate frame of the model,
+        # and by default the implicit __model__ frame is attached to it.
+        # Note: selecting the wrong canonical link would produce an invalid tree having
+        #       unconnected links and joints, situation that would raise an error.
+        # Note: after building the tree from the rod.Model, it will be possible to change
+        #       the canonical link (also known as base link), operation that performs a
+        #       tree re-balancing that would produce a new model having its __model__
+        #       frame not attached to its canonical link.
+        root_node_name = model.get_canonical_link()
+        logging.debug(msg=f"Selecting '{root_node_name}' as canonical link")
+        assert root_node_name in nodes_links_dict, root_node_name
+
+        # Furthermore, existing frames are extra elements that could be optionally
+        # attached to the kinematic tree (but by default they're not part of it).
+        # Create a dict mapping frame names to frame nodes, for easy retrieval.
+        nodes_frames_dict: Dict[str, TreeFrame] = {
+            # Add a frame node for each frame in the model
+            **{frame.name: TreeFrame(_source=frame) for frame in model.frames()},
+            # Add implicit frames used in the SDF specification (__model__).
+            # The following frames are attached to the first link found in the model
+            # description and never moved, so that all elements expressing their pose
+            # w.r.t. these frames always remain valid.
+            TreeFrame.MODEL: TreeFrame(
+                _source=rod.Frame(
+                    name=TreeFrame.MODEL,
+                    attached_to=root_node_name,
+                    pose=model.pose,
+                ),
+            ),
+            model.name: TreeFrame(
+                _source=rod.Frame(
+                    name=model.name, attached_to=root_node_name, pose=model.pose
+                )
+            ),
+        }
+
+        # Check that links and frames have unique names
+        assert len(
+            set(list(nodes_links_dict.keys()) + list(nodes_frames_dict.keys()))
+        ) == (len(nodes_links_dict) + len(nodes_frames_dict))
+
+        # Use joints to connect nodes by defining their parent and children
+        for joint in model.joints():
+
+            if joint.child == TreeFrame.WORLD:
+                msg = f"A joint cannot have '{TreeFrame.WORLD}' as child"
+                raise RuntimeError(msg)
+
+            # Get the parent and child nodes of the joint
+            child_node = nodes_links_dict[joint.child]
+            parent_node = nodes_links_dict[joint.parent]
+
+            # Check that the dict is correct
+            assert child_node.name() == joint.child, (child_node.name(), joint.child)
+            assert parent_node.name() == joint.parent, (
+                parent_node.name(),
+                joint.parent,
+            )
+
+            # Assign to each child node their parent
+            child_node.parent = parent_node
+
+            # Assign to each node their children, and make sure they are unique
+            if child_node.name() not in {n.name() for n in parent_node.children}:
+                parent_node.children.append(child_node)
+
+        # Compute the tree traversal with BFS algorithm.
+        # If the model is fixed-base, the world node is not part of the tree and the
+        # joint connecting to world will be removed.
+        all_node_names_in_tree = [
+            n.name()
+            for n in list(
+                KinematicTree.breadth_first_search(
+                    root=nodes_links_dict[root_node_name]
+                )
+            )
+        ]
+
+        # Get all the joints part of the kinematic tree ...
+        joints_in_tree_names = [
+            j.name
+            for j in model.joints()
+            if {j.parent, j.child}.issubset(all_node_names_in_tree)
+        ]
+        joints_in_tree = [j for j in model.joints() if j.name in joints_in_tree_names]
+
+        # ... and those that are not
+        joints_not_in_tree = [
+            j for j in model.joints() if j.name not in joints_in_tree_names
+        ]
+
+        # A valid rod.Model does not have any dangling link and any unconnected joints.
+        # Here we check that the rod.Model contains a valid tree representation.
+        found_num_extra_joints = len(joints_not_in_tree)
+        expected_num_extra_joints = 1 if model.is_fixed_base() else 0
+
+        if found_num_extra_joints != expected_num_extra_joints:
+
+            if model.is_fixed_base() and found_num_extra_joints == 0:
+                raise RuntimeError("Failed to find joint connecting the model to world")
+
+            unexpected_joint_names = [j.name for j in joints_not_in_tree]
+            raise RuntimeError(f"Found unexpected joints: {unexpected_joint_names}")
+
+        # Handle connection to world of fixed-base models
+        if model.is_fixed_base():
+
+            assert len(joints_not_in_tree) == 1
+            world_to_base_joint = joints_not_in_tree[0]
+
+            # Create a temporary edge so that we can reuse the logic implemented for
+            # the link lumping process
+            world_to_base_edge = TreeEdge(
+                parent=nodes_links_dict[world_to_base_joint.parent],
+                child=nodes_links_dict[world_to_base_joint.child],
+                _source=world_to_base_joint,
+            )
+
+            # Produce new nodes and frames by removing the edge connecting base to world.
+            # One of the additional frame will be the world frame.
+            new_base_node, additional_frames = KinematicTree.remove_edge(
+                edge=world_to_base_edge, keep_parent=False
+            )
+            assert any([f.name() == TreeFrame.WORLD for f in additional_frames])
+
+            # Replace the former base node with the new base node
+            nodes_links_dict[new_base_node.name()] = new_base_node
+
+            # Add all the additional frames created by the edge removal process
+            nodes_frames_dict = {
+                **nodes_frames_dict,
+                **{f.name(): f for f in additional_frames},
+            }
+
+            # Remove the world node from the nodes dictionary since it was
+            # converted to frame and already added to the frames dictionary
+            world_node = nodes_links_dict.pop(TreeFrame.WORLD)
+            assert world_node is not None
+
+        else:
+
+            # Remove the world node from the nodes dictionary since it's unconnected...
+            world_node = nodes_links_dict.pop(TreeFrame.WORLD)
+
+            # ... and add it as an explicit frame attached to the root node
+            nodes_frames_dict[world_node.name()] = TreeFrame.from_node(
+                node=world_node, attached_to=nodes_links_dict[root_node_name]
+            )
+
+        # Create an edge for all joints
+        edges_dict = {
+            joint.name: TreeEdge(
+                parent=nodes_links_dict[joint.parent],
+                child=nodes_links_dict[joint.child],
+                _source=joint,
+            )
+            for joint in joints_in_tree
+        }
+
+        # Build the tree, it assigns indices upon construction
+        tree = KinematicTree(
+            root=nodes_links_dict[root_node_name],
+            joints=list(edges_dict.values()),
+            frames=list(nodes_frames_dict.values()),
+            model=model,
+        )
+
+        return tree
+
+    @staticmethod
+    def remove_edge(
+        edge: TreeEdge, keep_parent: bool = True
+    ) -> Tuple[DirectedTreeNode, Sequence[TreeFrame]]:
+
+        # Removed node: the node to remove.
+        # Replaced node: the node removed and replaced with the new node.
+        # New node: the new node that combines the removed and replaced nodes.
+
+        if keep_parent:
+            # Lump child into parent.
+            # This is the default behavior.
+            removed_node = edge.child
+            replaced_node = edge.parent
+            new_node = dataclasses.replace(replaced_node)
+
+        else:
+            # Lump parent into child.
+            # Can be useful when lumping the special world node into the base.
+            removed_node = edge.parent
+            replaced_node = edge.child
+            new_node = dataclasses.replace(replaced_node, parent=removed_node.parent)
+
+        # Check if a link has non-trivial inertial parameters
+        def has_zero_inertial(link: Union[rod.common.Element, rod.Link]) -> bool:
+
+            if not isinstance(link, rod.Link):
+                return True
+
+            if link.inertial is None:
+                return True
+
+            return np.allclose(link.inertial.mass, 0.0) and np.allclose(
+                link.inertial.inertia, np.zeros(shape=(3, 3))
+            )
+
+        # The new node has the same inertial parameters of the removed node if the
+        # removed node has zero inertial parameters.
+        # In this case, the new node is equivalent to the removed one and its name can
+        # be the same. We return the new node and the two new frames (the removed node
+        # -either parent or child- and the removed edge).
+        if has_zero_inertial(link=removed_node._source):
+            return new_node, new_frames
+
+        # ========================
+        # Lump inertial properties
+        # ========================
+
+        raise NotImplementedError("Inertial parameters lumping")
+
+    @functools.cached_property
+    def links_dict(self) -> Dict[str, DirectedTreeNode]:
+
+        return self.nodes_dict
+
+    @functools.cached_property
+    def frames_dict(self) -> Dict[str, TreeFrame]:
+
+        return {frame.name(): frame for frame in self.frames}
+
+    @functools.cached_property
+    def joints_dict(self) -> Dict[str, TreeEdge]:
+
+        return {joint.name(): joint for joint in self.joints}
+
+    @functools.cached_property
+    def joints_connection_dict(self) -> Dict[Tuple[str, str], TreeEdge]:
+
+        return {(j.parent.name(), j.child.name()): j for j in self.joints}

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -1,0 +1,91 @@
+import copy
+import dataclasses
+
+import numpy as np
+import numpy.typing as npt
+
+import rod
+from rod.kinematics.kinematic_tree import KinematicTree
+from rod.tree import TreeFrame
+from rod.utils.frame_convention import FrameConvention
+
+
+@dataclasses.dataclass
+class TreeTransforms:
+
+    kinematic_tree: KinematicTree = dataclasses.dataclass(init=False)
+
+    @staticmethod
+    def build(
+        model: rod.Model,
+        is_top_level: bool = True,
+        prevent_switching_frame_convention: bool = False,
+    ) -> "TreeTransforms":
+
+        model = copy.deepcopy(model)
+
+        model.resolve_frames(is_top_level=is_top_level, explicit_frames=True)
+
+        if not prevent_switching_frame_convention:
+            model.switch_frame_convention(frame_convention=FrameConvention.Urdf)
+
+        return TreeTransforms(
+            kinematic_tree=KinematicTree.build(model=model, is_top_level=is_top_level)
+        )
+
+    def transform(self, name: str) -> npt.NDArray:
+
+        if name == TreeFrame.WORLD:
+            return np.eye(4)
+
+        if name in {TreeFrame.MODEL, self.kinematic_tree.model.name}:
+
+            relative_to = self.kinematic_tree.model.pose.relative_to
+            assert relative_to in {None, ""}, (relative_to, name)
+            return self.kinematic_tree.model.pose.transform()
+
+        if name in self.kinematic_tree.joint_names():
+
+            edge = self.kinematic_tree.joints_dict[name]
+            assert edge.name() == name
+
+            # Get the pose of the frame in which the node's pose is expressed
+            assert edge._source.pose.relative_to not in {"", None}
+            x_H_E = edge._source.pose.transform()
+            W_H_x = self.transform(name=edge._source.pose.relative_to)
+
+            # Compute the world-to-node transform
+            # TODO: this assumes all joint positions to be 0
+            W_H_E = W_H_x @ x_H_E
+
+            return W_H_E
+
+        if (
+            name in self.kinematic_tree.link_names()
+            or name in self.kinematic_tree.frame_names()
+        ):
+
+            element = (
+                self.kinematic_tree.links_dict[name]
+                if name in self.kinematic_tree.link_names()
+                else self.kinematic_tree.frames_dict[name]
+            )
+            assert element.name() == name
+
+            # Get the pose of the frame in which the node's pose is expressed
+            assert element._source.pose.relative_to not in {"", None}
+            x_H_N = element._source.pose.transform()
+            W_H_x = self.transform(name=element._source.pose.relative_to)
+
+            # Compute and cache the world-to-node transform
+            W_H_N = W_H_x @ x_H_N
+
+            return W_H_N
+
+        raise ValueError(name)
+
+    def relative_transform(self, relative_to: str, name: str) -> npt.NDArray:
+
+        return np.linalg.inv(self.transform(name=relative_to)) @ self.transform(
+            name=name
+        )

--- a/src/rod/model.py
+++ b/src/rod/model.py
@@ -9,6 +9,7 @@ from .common import Frame, Pose
 from .element import Element
 from .joint import Joint
 from .link import Link
+from .utils.frame_convention import FrameConvention
 
 
 @dataclasses.dataclass
@@ -136,3 +137,20 @@ class Model(Element):
         resolve_frames.resolve_model_frames(
             model=self, is_top_level=is_top_level, explicit_frames=explicit_frames
         )
+
+    def switch_frame_convention(
+        self,
+        frame_convention: FrameConvention,
+        is_top_level: bool = True,
+        explicit_frames: bool = True,
+    ) -> None:
+
+        from rod.utils.frame_convention import switch_frame_convention
+
+        switch_frame_convention(
+            model=self,
+            frame_convention=frame_convention,
+            is_top_level=is_top_level,
+        )
+
+        self.resolve_frames(is_top_level=is_top_level, explicit_frames=explicit_frames)

--- a/src/rod/model.py
+++ b/src/rod/model.py
@@ -126,3 +126,13 @@ class Model(Element):
 
         assert isinstance(self.joint, list), type(self.joint)
         return self.joint
+
+    def resolve_frames(
+        self, is_top_level: bool = True, explicit_frames: bool = True
+    ) -> None:
+
+        from rod.utils import resolve_frames
+
+        resolve_frames.resolve_model_frames(
+            model=self, is_top_level=is_top_level, explicit_frames=explicit_frames
+        )

--- a/src/rod/tree/__init__.py
+++ b/src/rod/tree/__init__.py
@@ -1,0 +1,2 @@
+from .directed_tree import DirectedTree
+from .tree_elements import DirectedTreeNode, TreeEdge, TreeElement, TreeFrame

--- a/src/rod/tree/directed_tree.py
+++ b/src/rod/tree/directed_tree.py
@@ -1,0 +1,125 @@
+import collections
+import dataclasses
+import functools
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+from .tree_elements import DirectedTreeNode
+
+
+@dataclasses.dataclass(frozen=True)
+class DirectedTree(collections.Sequence):
+
+    root: DirectedTreeNode
+
+    def __post_init__(self):
+
+        node_names = self.nodes_dict.keys()
+
+        # We perform many tree operations using the node name as unique identifier.
+        # Therefore, the node name must be unique.
+        if len(node_names) != len(set(node_names)):
+            raise RuntimeError("Nodes of a directed tree must have unique names")
+
+        # Assign node indices. The node index starts with 0 assigned to the root node.
+        for node_idx, node in enumerate(self):
+            node.index = node_idx
+
+    @functools.cached_property
+    def nodes(self) -> List[DirectedTreeNode]:
+        return list(iter(self))
+
+    @functools.cached_property
+    def nodes_dict(self) -> Dict[str, DirectedTreeNode]:
+
+        return {node.name(): node for node in iter(self)}
+
+    @staticmethod
+    def breadth_first_search(
+        root: DirectedTreeNode,
+        sort_children: Optional[Callable[[Any], Any]] = lambda node: node.name(),
+    ) -> Iterable[DirectedTreeNode]:
+
+        queue = [root]
+
+        # We assume that nodes have a unique name, and we mark a node as visited by
+        # storing its name. This assumption speeds up considerably object comparison.
+        visited = list()
+        visited.append(root.name)
+
+        yield root
+
+        while len(queue) > 0:
+
+            node = queue.pop(0)
+
+            # Note: sorting the nodes with their name so that the order of children
+            #       insertion does not matter when assigning the node index
+            for child in sorted(node.children, key=sort_children):
+
+                if child.name in visited:
+                    continue
+
+                visited.append(child.name)
+                queue.append(child)
+
+                yield child
+
+    def pretty_print(self) -> None:
+
+        import pptree
+
+        pptree.print_tree(
+            current_node=self.root,
+            childattr="children",
+            nameattr="tree_label",
+            horizontal=True,
+        )
+
+    def __getitem__(
+        self, key: Union[int, slice, str]
+    ) -> Union[DirectedTreeNode, List[DirectedTreeNode]]:
+
+        # Get the nodes' dictionary (already inserted in order following BFS)
+        nodes_dict = self.nodes_dict
+
+        if isinstance(key, str):
+
+            if key not in nodes_dict.keys():
+                raise KeyError(key)
+
+            return nodes_dict[key]
+
+        if isinstance(key, int):
+
+            if key > len(nodes_dict):
+                raise IndexError(key)
+
+            return list(nodes_dict.values())[key]
+
+        if isinstance(key, slice):
+
+            return list(nodes_dict.values())[key]
+
+        raise TypeError(type(key).__name__)
+
+    def __len__(self) -> int:
+
+        return len(self.nodes_dict)
+
+    def __iter__(self) -> Iterable[DirectedTreeNode]:
+
+        yield from DirectedTree.breadth_first_search(root=self.root)
+
+    def __reversed__(self) -> Iterable[DirectedTreeNode]:
+
+        yield from reversed(self)
+
+    def __contains__(self, item: Union[str, DirectedTreeNode]) -> bool:
+
+        if isinstance(item, str):
+            return item in self.nodes_dict.keys()
+
+        if isinstance(item, DirectedTreeNode):
+            return item.name() in self.nodes_dict.keys()
+
+        raise TypeError(type(item).__name__)

--- a/src/rod/tree/tree_elements.py
+++ b/src/rod/tree/tree_elements.py
@@ -1,0 +1,159 @@
+import abc
+import dataclasses
+from typing import ClassVar, List, Optional, Union
+
+import rod
+from rod import logging
+
+
+class TreeElement(abc.ABC):
+
+    index: Optional[int] = dataclasses.field(default=None, init=False)
+
+    @abc.abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def pose(self) -> rod.Pose:
+        pass
+
+    def __eq__(self, other) -> bool:
+
+        if not isinstance(other, type(self)):
+            return False
+
+        return self.name() == other.name()
+
+    def __hash__(self):
+
+        return hash(str(type(self)) + self.name())
+
+
+@dataclasses.dataclass(eq=False)
+class DirectedTreeNode(TreeElement):
+
+    parent: Optional["DirectedTreeNode"] = None
+    children: List["DirectedTreeNode"] = dataclasses.field(default_factory=list)
+
+    _source: Optional[rod.Link] = dataclasses.field(default=None, repr=False)
+
+    def name(self) -> str:
+        return self._source.name
+
+    def pose(self) -> rod.Pose:
+
+        if self._source is not None and self._source.pose is not None:
+            return self._source.pose
+        else:
+            return rod.Pose(relative_to="world")
+
+    @property
+    def tree_label(self) -> str:
+
+        return (
+            f"#{self.index}_<{self.name()}>"
+            if self.index is not None
+            else f"<{self.name()}>"
+        )
+
+    def __str__(self) -> str:
+
+        content_string = "name={}, index={}, parent={}, children={}".format(
+            self.name(),
+            self.index,
+            self.parent.name() if self.parent is not None else str(None),
+            [c.name() for c in self.children],
+        )
+
+        return f"{type(self).__name__}({content_string})"
+
+
+@dataclasses.dataclass(eq=False)
+class TreeEdge(TreeElement):
+
+    child: DirectedTreeNode
+    parent: DirectedTreeNode
+
+    _source: Optional[rod.Joint] = dataclasses.field(default=None, repr=False)
+
+    def pose(self) -> rod.Pose:
+
+        return self._source.pose
+
+    def name(self) -> str:
+        return self._source.name
+
+    def __str__(self) -> str:
+
+        content_string = "name={}, parent={}, child={}".format(
+            self.name(), self.parent, self.child
+        )
+
+        return f"{type(self).__name__}({content_string})"
+
+
+@dataclasses.dataclass(eq=False)
+class TreeFrame(TreeElement):
+
+    WORLD: ClassVar[str] = "world"
+    MODEL: ClassVar[str] = "__model__"
+
+    _source: Optional[rod.Frame] = dataclasses.field(default=None, repr=False)
+
+    def name(self) -> str:
+        return self._source.name
+
+    def attached_to(self) -> str:
+        return self._source.attached_to
+
+    def pose(self) -> rod.Pose:
+        return self._source.pose
+
+    def __str__(self) -> str:
+
+        content_string = "name={}, index={}, attached_to={}".format(
+            self.name(), self.index, self.attached_to()
+        )
+
+        return f"{type(self).__name__}({content_string})"
+
+    @staticmethod
+    def from_node(
+        node: DirectedTreeNode,
+        attached_to: Union[DirectedTreeNode, "TreeFrame", TreeEdge] = None,
+    ) -> "TreeFrame":
+
+        attached_to = attached_to if attached_to is not None else node.parent
+
+        logging.debug(
+            msg="Node '{}' became a frame attached to '{}'".format(
+                node.name(), attached_to.name() if attached_to is not None else "None"
+            )
+        )
+
+        return TreeFrame(
+            _source=rod.Frame(
+                name=node.name(), pose=node._source.pose, attached_to=attached_to.name()
+            )
+        )
+
+    @staticmethod
+    def from_edge(
+        edge: TreeEdge,
+        attached_to: Union[DirectedTreeNode, "TreeFrame", TreeEdge] = None,
+    ) -> "TreeFrame":
+
+        attached_to = attached_to if attached_to is not None else edge.parent
+
+        logging.debug(
+            msg="Edge '{}' became a frame attached to '{}'".format(
+                edge.name(), attached_to.name() if attached_to is not None else "None"
+            )
+        )
+
+        return TreeFrame(
+            _source=rod.Frame(
+                name=edge.name(), pose=edge._source.pose, attached_to=attached_to.name()
+            )
+        )

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -1,0 +1,235 @@
+import enum
+from collections import defaultdict
+
+import rod
+from rod import logging
+
+
+class FrameConvention(enum.IntEnum):
+
+    Model = enum.auto()
+    Sdf = enum.auto()
+    Urdf = enum.auto()
+    World = enum.auto()
+
+
+def switch_frame_convention(
+    model: "rod.Model", frame_convention: FrameConvention, is_top_level: bool = True
+) -> None:
+
+    # Resolve all implicit reference frames using Sdf convention
+    model.resolve_frames(is_top_level=is_top_level, explicit_frames=True)
+
+    # =============================================================
+    # Define the default reference frames of the different elements
+    # =============================================================
+
+    if frame_convention is FrameConvention.World:
+
+        reference_frame_model = lambda m: "world"
+        reference_frame_links = lambda l: "world"
+        reference_frame_frames = lambda f: "world"
+        reference_frame_joints = lambda j: "world"
+        reference_frame_visuals = lambda v: "world"
+        reference_frame_inertials = lambda i, parent_link: "world"
+        reference_frame_collisions = lambda c: "world"
+
+    elif frame_convention is FrameConvention.Model:
+
+        reference_frame_model = lambda m: "world"
+        reference_frame_links = lambda l: "__model__"
+        reference_frame_frames = lambda f: "__model__"
+        reference_frame_joints = lambda j: "__model__"
+        reference_frame_visuals = lambda v: "__model__"
+        reference_frame_inertials = lambda i, parent_link: "__model__"
+        reference_frame_collisions = lambda c: "__model__"
+
+    elif frame_convention is FrameConvention.Sdf:
+
+        visual_name_to_parent_link = {
+            visual_name: parent_link
+            for d in [{v.name: link for v in link.visuals()} for link in model.links()]
+            for visual_name, parent_link in d.items()
+        }
+
+        collision_name_to_parent_link = {
+            collision_name: parent_link
+            for d in [
+                {c.name: link for c in link.collisions()} for link in model.links()
+            ]
+            for collision_name, parent_link in d.items()
+        }
+
+        reference_frame_model = lambda m: "world"
+        reference_frame_links = lambda l: "__model__"
+        reference_frame_frames = lambda f: "__model__"
+        reference_frame_joints = lambda j: joint.child
+        reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
+        reference_frame_inertials = lambda i, parent_link: parent_link.name
+        reference_frame_collisions = lambda c: collision_name_to_parent_link[
+            c.name
+        ].name
+
+    elif frame_convention is FrameConvention.Urdf:
+
+        visual_name_to_parent_link = {
+            visual_name: parent_link
+            for d in [{v.name: link for v in link.visuals()} for link in model.links()]
+            for visual_name, parent_link in d.items()
+        }
+
+        collision_name_to_parent_link = {
+            collision_name: parent_link
+            for d in [
+                {c.name: link for c in link.collisions()} for link in model.links()
+            ]
+            for collision_name, parent_link in d.items()
+        }
+
+        link_name_to_parent_joint_names = defaultdict(list)
+
+        for j in model.joints():
+            link_name_to_parent_joint_names[j.child].append(j.name)
+
+        reference_frame_model = lambda m: "world"
+        reference_frame_links = lambda l: link_name_to_parent_joint_names[l.name][0]
+        reference_frame_frames = lambda f: "__model__"
+        reference_frame_joints = lambda j: j.parent
+        reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
+        reference_frame_inertials = lambda i, parent_link: parent_link.name
+        reference_frame_collisions = lambda c: collision_name_to_parent_link[
+            c.name
+        ].name
+
+    else:
+        raise ValueError(frame_convention)
+
+    # =========================================
+    # Process the reference frames of the model
+    # =========================================
+
+    from rod.kinematics.tree_transforms import TreeTransforms
+
+    # Create the tree from the model, using the original frame convention
+    # (otherwise it would call this helper obtaining an infinite loop)
+    kin = TreeTransforms.build(
+        model=model, is_top_level=is_top_level, prevent_switching_frame_convention=True
+    )
+
+    if is_top_level:
+        assert model.pose.relative_to in {"", None}
+
+    else:
+        # Adjust the reference frame of the sub-model
+        if model.pose.relative_to != reference_frame_model:
+
+            x_H_model = model.pose.transform()
+            target_H_x = kin.relative_transform(
+                relative_to=reference_frame_model(m=model),
+                name=model.pose.relative_to,
+            )
+
+            model.pose = rod.Pose.from_transform(
+                relative_to=reference_frame_model(m=model),
+                transform=target_H_x @ x_H_model,
+            )
+
+    # Adjust the reference frames of all sub-models
+    for sub_model in model.models():
+
+        logging.info(
+            "Model composition not yet supported, ignoring '{}/{}'".format(
+                model.name, sub_model.name
+            )
+        )
+
+    # Adjust the reference frames of all joints
+    for joint in model.joints():
+
+        x_H_joint = joint.pose.transform()
+        target_H_x = kin.relative_transform(
+            relative_to=reference_frame_joints(j=joint),
+            name=joint.pose.relative_to,
+        )
+
+        joint.pose = rod.Pose.from_transform(
+            relative_to=reference_frame_joints(j=joint),
+            transform=target_H_x @ x_H_joint,
+        )
+
+    # Adjust the reference frames of all frames
+    for frame in model.frames():
+
+        x_H_frame = frame.pose.transform()
+        target_H_x = kin.relative_transform(
+            relative_to=reference_frame_frames(f=frame),
+            name=frame.pose.relative_to,
+        )
+
+        frame.pose = rod.Pose.from_transform(
+            relative_to=reference_frame_frames(f=frame),
+            transform=target_H_x @ x_H_frame,
+        )
+
+    # Adjust the reference frames of all links
+    for link in model.links():
+
+        if link.name != model.get_canonical_link():
+            relative_to = reference_frame_links(l=link)
+        else:
+            # For fixed-base models, the URDF will also have a world-to-base joint,
+            # whose origin will be the pose of the canonical link of the SDF model.
+            # Instead, for floating-base models, we use __model__ as reference frame
+            # for the canonical link, that in any case must be a trivial pose since
+            # any other transform would not be supported by the URDF specification.
+            relative_to = "world" if model.is_fixed_base() else "__model__"
+
+        # Link pose
+        x_H_link = link.pose.transform()
+        target_H_x = kin.relative_transform(
+            relative_to=relative_to,
+            name=link.pose.relative_to,
+        )
+        link.pose = rod.Pose.from_transform(
+            relative_to=relative_to,
+            transform=target_H_x @ x_H_link,
+        )
+
+        # Inertial pose
+        x_H_inertial = link.inertial.pose.transform()
+        target_H_x = kin.relative_transform(
+            relative_to=reference_frame_inertials(i=link.inertial, parent_link=link),
+            name=link.inertial.pose.relative_to,
+        )
+        link.inertial.pose = rod.Pose.from_transform(
+            relative_to=reference_frame_inertials(i=link.inertial, parent_link=link),
+            transform=target_H_x @ x_H_inertial,
+        )
+
+        # Visuals pose
+        for visual in link.visuals():
+
+            x_H_visual = visual.pose.transform()
+            target_H_x = kin.relative_transform(
+                relative_to=reference_frame_visuals(v=visual),
+                name=visual.pose.relative_to,
+            )
+
+            visual.pose = rod.Pose.from_transform(
+                relative_to=reference_frame_visuals(v=visual),
+                transform=target_H_x @ x_H_visual,
+            )
+
+        # Collisions pose
+        for collision in link.collisions():
+
+            x_H_collision = collision.pose.transform()
+            target_H_x = kin.relative_transform(
+                relative_to=reference_frame_collisions(c=collision),
+                name=collision.pose.relative_to,
+            )
+
+            collision.pose = rod.Pose.from_transform(
+                relative_to=reference_frame_collisions(c=collision),
+                transform=target_H_x @ x_H_collision,
+            )

--- a/src/rod/utils/resolve_frames.py
+++ b/src/rod/utils/resolve_frames.py
@@ -1,0 +1,97 @@
+import functools
+from typing import List, Union
+
+import numpy as np
+
+import rod
+from rod.element import Element
+
+
+def update_element_with_pose(
+    element: Element, default_relative_to: Union[str, List[str]], explicit_frames: bool
+) -> None:
+
+    if not hasattr(element, "pose"):
+        raise ValueError("The input element has no 'pose' attribute")
+
+    # If there are multiple defaults to detect (e.g. __model__ and <model_name>),
+    # we select the first entry of the list as real default
+    default_relative_to = (
+        [default_relative_to]
+        if isinstance(default_relative_to, str)
+        else default_relative_to
+    )
+
+    if len(default_relative_to) < 1:
+        raise ValueError(default_relative_to)
+
+    # Either add a new pose if there is any, or specify the reference frame if missing
+    if explicit_frames:
+
+        # Add trivial pose
+        if element.pose is None:
+            element.pose = rod.Pose(
+                pose=list(np.zeros(6)), relative_to=default_relative_to[0]
+            )
+
+        # Explicitly define reference frame
+        else:
+            if element.pose.relative_to in {"", None}:
+                element.pose.relative_to = default_relative_to[0]
+
+    # Remove the reference frame if the element has a pose wrt the default choice
+    else:
+
+        if element.pose is not None and element.pose.relative_to in {"", None}.union(
+            default_relative_to
+        ):
+
+            # Remove trivial pose
+            if np.allclose(element.pose.pose, np.zeros(6)):
+                element.pose = None
+
+            # Remove implicit reference frame
+            else:
+                element.pose.relative_to = ""
+
+
+def resolve_model_frames(
+    model: "rod.Model", is_top_level: bool = True, explicit_frames: bool = True
+) -> None:
+
+    # Close the helper for compactness
+    update_element = functools.partial(
+        update_element_with_pose, explicit_frames=explicit_frames
+    )
+
+    # Update the model
+    if is_top_level and explicit_frames:
+        if model.pose is None:
+            model.pose = rod.Pose(pose=list(np.zeros(6)))
+        else:
+            assert model.pose.relative_to in {"", None}
+    else:
+        update_element(element=model, default_relative_to="world")
+
+    # Update the links and its children elements
+    for link in model.links():
+
+        update_element(element=link, default_relative_to=["__model__", model.name])
+
+        update_element(element=link.inertial, default_relative_to=link.name)
+
+        for visual in link.visuals():
+            update_element(element=visual, default_relative_to=link.name)
+
+        for collision in link.collisions():
+            update_element(element=collision, default_relative_to=link.name)
+
+    # Update the joints
+    for joint in model.joints():
+        update_element(element=joint, default_relative_to=joint.child)
+
+    # Update the sub-models
+    for sub_model in model.models():
+        resolve_model_frames(
+            model=sub_model, is_top_level=False, explicit_frames=explicit_frames
+        )


### PR DESCRIPTION
This PR introduces a number of new features, all targeted to be used as utilities for processing a `rod.Model` as a tree. Some of the feature below or future features are taken from [`jaxsim.parsers`](https://github.com/ami-iit/jaxsim/tree/f088a1dcadd142844a812595149c877e604057b2/src/jaxsim/parsers), that could be replaced in the future by these new `rod` features.

## 1. Creating directed trees

Although SDFormat supports closed kinematic loops / parallel robots ([example](url)), `rod` currently doesn't, as by the way also URDF. Excluding these particular families of kinematics, any robot model could be modelled as a _directed tree_ (i.e. an oriented Direct Acyclic Graph with nodes restricted to have just one parent).

In our directed tree:

- Links are the nodes
- Joints are the edges

Furthermore, in order to support SDF frames, we also allow attaching extra elements to both links and joints.

## 2. Computing forward kinematics

The new [`TreeTransforms`](https://github.com/ami-iit/rod/blob/5740164d24be0abc5355047daea7a753fed4598b/src/rod/kinematics/tree_transforms.py#L13-L16) class allows to compute the forward kinematics of links, frames, and joints. The pose of these elements can be expressed wrt any other element part of the `rod.Model`.

Currently this FK is meant to be used just for performing computations on the kinematic tree, that means that we consider all joints having a zero positions. This limitation will be removed in future PRs.

## 3. Resolving frames

A SDF model could have either [explicit or implicit frames](http://sdformat.org/tutorials?tut=pose_frame_semantics&ver=1.7#implicit-and-explicit-frames). To ease processing, this PR introduces a [resolve_model_frames](https://github.com/ami-iit/rod/blob/5740164d24be0abc5355047daea7a753fed4598b/src/rod/utils/resolve_frames.py#L58-L60) helper that adds to all elements of the model an explicit pose.

## 4. Switching frame convention

Partially related to feature 3, SDF has its own default convention of implicit frames when either the pose element is missing or the `relative_to` attribute is not set. This PR introduces a [`switch_frame_convention`](https://github.com/ami-iit/rod/blob/5740164d24be0abc5355047daea7a753fed4598b/src/rod/utils/frame_convention.py#L16-L18) helper that updates all transforms following different _frame conventions_:

- `Sdf`: converts all `rod.Pose` elements to use [the default reference frames of SDF](http://sdformat.org/tutorials?tut=pose_frame_semantics&ver=1.7#implicit-and-explicit-frames)
- `Model`: converts all `rod.Pose` elements to be expressed wrt their parent model (`__model__`)
- `World`: converts all `rod.Pose` elements to be expressed wrt the world frame
- `Urdf`: converts all `rod.Pose` elements to be expressed wrt the [equivalent defaults used in URDF](http://sdformat.org/tutorials?branch=proposal_to_documentation&tut=pose_frame_semantics_proposal#1-1-parity-with-urdf-using-pose-relative_to)

This is particularly useful especially for the last convention, for example if in the future we want to convert a deserialized SDF to URDF since serializing the XML having already the correct poses would be pretty easy.

## Future work

This PR is already useful as it is and I propose to merge it with these features that are already too many. Future PR will address some features left out:

- Implementation of [lumping links](https://github.com/ami-iit/rod/blob/5740164d24be0abc5355047daea7a753fed4598b/src/rod/kinematics/kinematic_tree.py#L303-L307) together (this PR only supports lumping a link with zero inertial properties, e.g. a URDF frame)[^1]
- Implement a [proper forward kinematics](https://github.com/ami-iit/rod/blob/5740164d24be0abc5355047daea7a753fed4598b/src/rod/kinematics/tree_transforms.py#L57-L59) that allows to specify joint positions
- Use the two features above to enable _model reduction_, i.e. removing a set of joints (possibly specifying their default position) and properly lump the removed links into the ones that remain [^2]

[^1]: could be taken from [`jaxsim.parser.descriptions.LinkDescription.lump_with`](https://github.com/ami-iit/jaxsim/blob/2df65f7f88baced7e07b3304c0151f4628a83834/src/jaxsim/parsers/descriptions/link.py#L35-L37) like other features of this PR
[^2]: could be taken from [`jaxsim.parsers.KinematicGraph.reduce`](https://github.com/ami-iit/jaxsim/blob/2df65f7f88baced7e07b3304c0151f4628a83834/src/jaxsim/parsers/kinematic_graph.py#L201)