### PR TITLE
Resolve URIs to mesh files

### DIFF
--- a/src/rod/sdf/model.py
+++ b/src/rod/sdf/model.py
@@ -120,6 +120,16 @@ class Model(Element):
         assert isinstance(self.joint, list), type(self.joint)
         return self.joint
 
+    def resolve_uris(self) -> None:
+        from rod.utils import resolve_uris
+
+        for link in self.links():
+            for visual in link.visuals():
+                resolve_uris.resolve_geometry_uris(geometry=visual.geometry)
+
+            for collision in link.collisions():
+                resolve_uris.resolve_geometry_uris(geometry=collision.geometry)
+
     def resolve_frames(
         self, is_top_level: bool = True, explicit_frames: bool = True
     ) -> None:

--- a/src/rod/utils/resolve_uris.py
+++ b/src/rod/utils/resolve_uris.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from typing import List
 
 from rod import Geometry, logging
 
@@ -8,7 +9,15 @@ def resolve_local_uri(uri: str) -> pathlib.Path:
     # Remove the prefix of the URI
     uri_no_prefix = uri.split(sep="//")[-1]
 
-    for path in os.environ["IGN_GAZEBO_RESOURCE_PATH"].split(":"):
+    paths = []
+    paths += paths_from_environment_variable("GZ_SIM_RESOURCE_PATH")
+    paths += paths_from_environment_variable("IGN_GAZEBO_RESOURCE_PATH")
+    paths += paths_from_environment_variable("GAZEBO_MODEL_PATH")
+
+    # Remove possible duplicates
+    paths = list(set(paths))
+
+    for path in paths:
         tentative = pathlib.Path(path) / uri_no_prefix
 
         if tentative.is_file():
@@ -24,3 +33,16 @@ def resolve_geometry_uris(geometry: Geometry) -> None:
         return
 
     geometry.mesh.uri = str(resolve_local_uri(uri=geometry.mesh.uri))
+
+
+def paths_from_environment_variable(variable_name: str) -> List[str]:
+    if variable_name not in os.environ:
+        return []
+
+    # Collect all paths removing the empty ones (if '::' is part of the variable)
+    paths = [p for p in os.environ[variable_name].split(":") if p != ""]
+
+    # Remove duplicates that might occur
+    paths = list(set(paths))
+
+    return paths

--- a/src/rod/utils/resolve_uris.py
+++ b/src/rod/utils/resolve_uris.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+
+from rod import Geometry, logging
+
+
+def resolve_local_uri(uri: str) -> pathlib.Path:
+    # Remove the prefix of the URI
+    uri_no_prefix = uri.split(sep="//")[-1]
+
+    for path in os.environ["IGN_GAZEBO_RESOURCE_PATH"].split(":"):
+        tentative = pathlib.Path(path) / uri_no_prefix
+
+        if tentative.is_file():
+            logging.debug(f"Resolved URI: '{tentative}'")
+            return tentative
+
+    raise RuntimeError(f"Failed to resolve URI: {uri}")
+
+
+def resolve_geometry_uris(geometry: Geometry) -> None:
+    # Resolve only mesh geometries
+    if geometry.mesh is None:
+        return
+
+    geometry.mesh.uri = str(resolve_local_uri(uri=geometry.mesh.uri))


### PR DESCRIPTION
This is an initial implementation of resolving local URIs of the form e.g. `<something>://dir/file.stl` where `<something>` is part of `IGN_GAZEBO_RESOURCE_PATH`.

After parsing a URDF/SDF model, calling `Model.resolve_uris()` will replace all the URIs with the real path to the local file.

Partially resolves #8. 