### PR TITLE
Add utilities to build primitive shapes

### DIFF
--- a/src/rod/builder/primitive_builder.py
+++ b/src/rod/builder/primitive_builder.py
@@ -1,0 +1,318 @@
+import abc
+import dataclasses
+from typing import Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+
+import rod
+from rod import logging
+
+
+@dataclasses.dataclass
+class PrimitiveBuilder(abc.ABC):
+    name: str
+    mass: float
+
+    element: Union[
+        rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual
+    ] = dataclasses.field(
+        default=None, init=False, repr=False, hash=False, compare=False
+    )
+
+    def build(
+        self,
+    ) -> Union[rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual]:
+        return self.element
+
+    # ================
+    # Abstract methods
+    # ================
+
+    @abc.abstractmethod
+    def _inertia(self) -> rod.Inertia:
+        pass
+
+    @abc.abstractmethod
+    def _geometry(self) -> rod.Geometry:
+        pass
+
+    # ================
+    # Element builders
+    # ================
+
+    def build_model(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> "PrimitiveBuilder":
+        self._check_element()
+
+        self.element = self._model(name=name, pose=pose)
+
+        return self
+
+    def build_link(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> "PrimitiveBuilder":
+        self._check_element()
+
+        self.element = self._link(name=name, pose=pose)
+
+        return self
+
+    def build_inertial(self, pose: Optional[rod.Pose] = None) -> "PrimitiveBuilder":
+        self._check_element()
+
+        self.element = self._inertial(pose=pose)
+
+        return self
+
+    def build_visual(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> "PrimitiveBuilder":
+        self._check_element()
+
+        self.element = self._visual(name=name, pose=pose)
+
+        return self
+
+    def build_collision(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> "PrimitiveBuilder":
+        self._check_element()
+
+        self.element = self._collision(name=name, pose=pose)
+
+        return self
+
+    # =================
+    # Element modifiers
+    # =================
+
+    def add_link(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+        link: Optional[rod.Link] = None,
+    ) -> "PrimitiveBuilder":
+        if not isinstance(self.element, rod.Model):
+            raise ValueError(type(self.element))
+
+        link = link if link is not None else self._link(name=name, pose=pose)
+
+        if pose is not None:
+            link.pose = pose
+
+        self.element.link = link
+
+        return self
+
+    def add_inertial(
+        self,
+        pose: Optional[rod.Pose] = None,
+        inertial: Optional[rod.Inertial] = None,
+    ) -> "PrimitiveBuilder":
+        if not isinstance(self.element, (rod.Model, rod.Link)):
+            raise ValueError(type(self.element))
+
+        if isinstance(self.element, rod.Model):
+            link = self.element.link
+
+        elif isinstance(self.element, rod.Link):
+            link = self.element
+
+        else:
+            raise ValueError(self.element)
+
+        inertial = inertial if inertial is not None else self._inertial(pose=pose)
+
+        if pose is not None:
+            inertial.pose = pose
+        else:
+            inertial.pose = PrimitiveBuilder.build_pose(relative_to=link.name)
+
+        link.inertial = inertial
+
+        return self
+
+    def add_visual(
+        self,
+        name: Optional[str] = None,
+        use_inertial_pose: bool = True,
+        pose: Optional[rod.Pose] = None,
+        visual: Optional[rod.Visual] = None,
+    ) -> "PrimitiveBuilder":
+        if not isinstance(self.element, (rod.Model, rod.Link)):
+            raise ValueError(type(self.element))
+
+        if isinstance(self.element, rod.Model):
+            link = self.element.link
+
+        elif isinstance(self.element, rod.Link):
+            link = self.element
+
+        else:
+            raise ValueError(self.element)
+
+        if pose is None and use_inertial_pose:
+            if link.inertial.pose is None:
+                msg = f"Inertial element of link '{link.name}' has no pose defined"
+                raise ValueError(msg)
+
+            pose = link.inertial.pose
+
+        visual = visual if visual is not None else self._visual(name=name, pose=pose)
+
+        if visual.name in [v.name for v in link.visuals()]:
+            msg = f"Visual '{visual.name}' already exists in link '{link.name}'"
+            raise ValueError(msg)
+
+        link.add_visual(visual=visual)
+
+        return self
+
+    def add_collision(
+        self,
+        name: Optional[str] = None,
+        use_inertial_pose: bool = True,
+        pose: Optional[rod.Pose] = None,
+        collision: Optional[rod.Collision] = None,
+    ) -> "PrimitiveBuilder":
+        if not isinstance(self.element, (rod.Model, rod.Link)):
+            raise ValueError(type(self.element))
+
+        if isinstance(self.element, rod.Model):
+            link = self.element.link
+
+        elif isinstance(self.element, rod.Link):
+            link = self.element
+
+        else:
+            raise ValueError(self.element)
+
+        if pose is None and use_inertial_pose:
+            if link.inertial.pose is None:
+                msg = f"Inertial element of link '{link.name}' has no pose defined"
+                raise ValueError(msg)
+
+            pose = link.inertial.pose
+
+        collision = (
+            collision
+            if collision is not None
+            else self._collision(name=name, pose=pose)
+        )
+
+        if collision.name in [c.name for c in link.collisions()]:
+            msg = f"Collision '{collision.name}' already exists in link '{link.name}'"
+            raise ValueError(msg)
+
+        link.add_collision(collision=collision)
+
+        return self
+
+    # ====================
+    # ROD element builders
+    # ====================
+
+    def _model(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> rod.Model:
+        name = name if name is not None else self.name
+        logging.debug(f"Building model '{name}'")
+
+        if pose is not None and pose.relative_to != "world":
+            raise ValueError("Model pose must be relative to 'world")
+
+        return rod.Model(
+            name=name,
+            pose=pose,
+        )
+
+    def _link(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> rod.Link:
+        return rod.Link(
+            name=name if name is not None else f"{self.name}_link",
+            pose=pose,
+        )
+
+    def _inertial(self, pose: Optional[rod.Pose] = None) -> rod.Inertial:
+        return rod.Inertial(
+            pose=pose,
+            mass=self.mass,
+            inertia=self._inertia(),
+        )
+
+    def _visual(
+        self,
+        name: Optional[str] = None,
+        pose: Optional[rod.Pose] = None,
+    ) -> rod.Visual:
+        name = name if name is not None else f"{self.name}_visual"
+
+        return rod.Visual(
+            name=name,
+            pose=pose,
+            geometry=self._geometry(),
+        )
+
+    def _collision(
+        self,
+        name: Optional[str],
+        pose: Optional[rod.Pose] = None,
+    ) -> rod.Collision:
+        name = name if name is not None else f"{self.name}_collision"
+
+        return rod.Collision(
+            name=name,
+            pose=pose,
+            geometry=self._geometry(),
+        )
+
+    # ===============
+    # Utility methods
+    # ===============
+
+    def _check_element(self) -> None:
+        if self.element is not None:
+            msg = f"Builder was already building a '{type(self.element)}' instance"
+            raise ValueError(msg)
+
+    @staticmethod
+    def build_pose(
+        pos: npt.NDArray = None,
+        rpy: npt.NDArray = None,
+        relative_to: str = None,
+        degrees: bool = None,
+        rotation_format: str = None,
+    ) -> Optional[rod.Pose]:
+        if pos is None and rpy is None:
+            return rod.Pose.from_transform(transform=np.eye(4), relative_to=relative_to)
+
+        pos = np.zeros(3) if pos is None else pos
+        rpy = np.zeros(3) if rpy is None else rpy
+
+        if pos.size != 3:
+            raise ValueError(pos.size)
+
+        if rpy.size != 3:
+            raise ValueError(rpy.size)
+
+        return rod.Pose(
+            pose=list(np.hstack([pos, rpy])),
+            relative_to=relative_to,
+            degrees=degrees,
+            rotation_format=rotation_format,
+        )

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -1,0 +1,56 @@
+import dataclasses
+
+import rod
+from rod.builder.primitive_builder import PrimitiveBuilder
+
+
+@dataclasses.dataclass
+class SphereBuilder(PrimitiveBuilder):
+    radius: float
+
+    def _inertia(self) -> rod.Inertia:
+        return rod.Inertia(
+            ixx=2 / 5 * self.mass * (self.radius) ** 2,
+            iyy=2 / 5 * self.mass * (self.radius) ** 2,
+            izz=2 / 5 * self.mass * (self.radius) ** 2,
+        )
+
+    def _geometry(self) -> rod.Geometry:
+        return rod.Geometry(sphere=rod.Sphere(radius=self.radius))
+
+
+@dataclasses.dataclass
+class BoxBuilder(PrimitiveBuilder):
+    x: float
+    y: float
+    z: float
+
+    def _inertia(self) -> rod.Inertia:
+        return rod.Inertia(
+            ixx=self.mass / 12 * (self.y**2 + self.z**2),
+            iyy=self.mass / 12 * (self.x**2 + self.z**2),
+            izz=self.mass / 12 * (self.x**2 + self.y**2),
+        )
+
+    def _geometry(self) -> rod.Geometry:
+        return rod.Geometry(box=rod.Box(size=[self.x, self.y, self.z]))
+
+
+@dataclasses.dataclass
+class CylinderBuilder(PrimitiveBuilder):
+    radius: float
+    length: float
+
+    def _inertia(self) -> rod.Inertia:
+        ixx_iyy = self.mass * (3 * self.radius**2 + self.length**2) / 12
+
+        return rod.Inertia(
+            ixx=ixx_iyy,
+            iyy=ixx_iyy,
+            izz=0.5 * self.mass * self.radius**2,
+        )
+
+    def _geometry(self) -> rod.Geometry:
+        return rod.Geometry(
+            cylinder=rod.Cylinder(radius=self.radius, length=self.length)
+        )

--- a/src/rod/sdf/link.py
+++ b/src/rod/sdf/link.py
@@ -133,3 +133,31 @@ class Link(Element):
 
         assert isinstance(self.collision, list), type(self.collision)
         return self.collision
+
+    def add_visual(self, visual: Visual) -> None:
+        if self.visual is None:
+            self.visual = visual
+            return
+
+        visuals = self.visual
+
+        if not isinstance(visuals, list):
+            assert isinstance(visuals, Visual), type(visuals)
+            visuals = [visuals]
+
+        visuals.append(visual)
+        self.visual = visuals
+
+    def add_collision(self, collision: Collision) -> None:
+        if self.collision is None:
+            self.collision = collision
+            return
+
+        collisions = self.collision
+
+        if not isinstance(collisions, list):
+            assert isinstance(collisions, Collision), type(collisions)
+            collisions = [collisions]
+
+        collisions.append(collision)
+        self.collision = collisions

--- a/src/rod/sdf/model.py
+++ b/src/rod/sdf/model.py
@@ -120,6 +120,20 @@ class Model(Element):
         assert isinstance(self.joint, list), type(self.joint)
         return self.joint
 
+    def add_frame(self, frame: Frame) -> None:
+        if self.frame is None:
+            self.frame = frame
+            return
+
+        frames = self.frame
+
+        if not isinstance(frames, list):
+            assert isinstance(frames, Frame)
+            frames = [frames]
+
+        frames.append(frame)
+        self.frame = frames
+
     def resolve_uris(self) -> None:
         from rod.utils import resolve_uris
 


### PR DESCRIPTION
Initial support of creating elements of primitive shapes.

Quick example:

```python

import numpy as np
import rod
from rod.builder import primitives

link_H_com = np.eye(4)
link_H_com[0:3, 3] = np.array([0, 0, 1.0])

model = (
    primitives.SphereBuilder(name="sphere", mass=1.0, radius=0.1)
    .build_model()
    .add_link()
    .add_inertial(pose=rod.Pose.from_transform(transform=link_H_com))
    .add_visual()
    .build()
)

sdf = rod.Sdf(version="1.9", model=model)

print(sdf.serialize(pretty=True))
sdf_string = sdf.serialize(pretty=True)
```