### PR TITLE
Add Continuous Integration test on parsing URDF models

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -50,9 +50,12 @@ jobs:
           name: dist
 
   test:
-    name: 'Python${{ matrix.python }}@${{ matrix.os }}'
+    name: 'Python${{ matrix.python }}@${{ matrix.type }}@${{ matrix.os }}'
     needs: package
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
@@ -60,18 +63,63 @@ jobs:
           - ubuntu-22.04
           - macos-latest
           - windows-latest
+        type:
+          - apt
+          - conda
         python:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+        exclude:
+          - os: macos-latest
+            type: apt
+          - os: windows-latest
+            type: apt
 
     steps:
 
       - name: Set up Python
+        if: matrix.type == 'apt'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: matrix.type == 'conda'
+        with:
+          python-version: ${{ matrix.python }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Install system dependencies
+        if: matrix.type == 'apt'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gazebo
+          # Remove following line as soon as iDynTree is available on Python 3.11:
+          pip install --pre idyntree
+
+      - name: Install conda dependencies
+        if: matrix.type == 'conda'
+        run: |
+          mamba install -y \
+            coloredlogs \
+            mashumaro \
+            numpy \
+            packaging \
+            scipy \
+            xmltodict \
+            black \
+            isort \
+            pptree \
+            idyntree \
+            pytest \
+            robot_descriptions
+            # pytest-icdiff \  # creates problems on macOS
+          mamba install -y gz-sim7 idyntree
 
       - name: Download Python packages
         uses: actions/download-artifact@v3
@@ -79,12 +127,24 @@ jobs:
           path: dist
           name: dist
 
-      - name: Install wheel
-        shell: bash
-        run: pip install dist/*.whl
+      - name: Install wheel (apt)
+        if: matrix.type == 'apt'
+        run: pip install "$(find dist/ -type f -name '*.whl')[all]"
+
+      - name: Install wheel (conda)
+        if: matrix.type == 'conda'
+        run: pip install --no-deps "$(find dist/ -type f -name '*.whl')[all]"
+
+      - name: Pip check
+        run: pip check
 
       - name: Import the package
         run: python -c "import rod"
+
+      - uses: actions/checkout@v3
+
+      - name: Run tests
+        run: pytest
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -142,8 +142,10 @@ jobs:
         run: python -c "import rod"
 
       - uses: actions/checkout@v3
+        if: matrix.os != 'windows-latest'
 
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: pytest
 
   publish:

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,9 +68,19 @@ style =
     isort
 pptree =
     pptree
+test =
+    idyntree
+    pytest
+    pytest-icdiff
+    robot-descriptions
 all =
     %(style)s
     %(pptree)s
+    %(test)s
 
 [options.packages.find]
 where = src
+
+[tool:pytest]
+addopts = -rsxX -v --strict-markers
+testpaths = tests

--- a/tests/test_urdf_parsing.py
+++ b/tests/test_urdf_parsing.py
@@ -1,0 +1,114 @@
+import pytest
+import robot_descriptions
+import robot_descriptions.loaders.idyntree
+from utils_models import ModelFactory, Robot
+
+import rod
+
+
+@pytest.mark.parametrize(
+    "robot",
+    [
+        Robot.iCub,
+        Robot.DoublePendulum,
+        Robot.Cassie,
+        Robot.Ur10,
+        Robot.AtlasV4,
+        Robot.Ergocub,
+    ],
+)
+def test_urdf_parsing(robot: Robot) -> None:
+    """Test parsing URDF files."""
+
+    # Get the path to the URDF
+    urdf_path = ModelFactory.get_model_description(robot=robot)
+
+    # Check that it fails if is_urdf=False and the resource is a path
+    with pytest.raises(RuntimeError):
+        _ = rod.Sdf.load(sdf=urdf_path, is_urdf=False)
+
+    # Check that it fails if is_urdf=False and the resource is a path string
+    with pytest.raises(RuntimeError):
+        _ = rod.Sdf.load(sdf=str(urdf_path), is_urdf=False)
+
+    # Check that it fails if is_urdf=False and the resource is an urdf string
+    with pytest.raises(RuntimeError):
+        _ = rod.Sdf.load(sdf=urdf_path.read_text(), is_urdf=False)
+
+    # Check that it fails if is_urdf=False and the resource is an urdf string
+    with pytest.raises(RuntimeError):
+        _ = rod.Sdf.load(sdf=urdf_path.read_text(), is_urdf=None)
+
+    # The following instead should succeed
+    _ = rod.Sdf.load(sdf=urdf_path, is_urdf=None)
+    _ = rod.Sdf.load(sdf=urdf_path, is_urdf=True)
+    _ = rod.Sdf.load(sdf=str(urdf_path), is_urdf=None)
+    _ = rod.Sdf.load(sdf=str(urdf_path), is_urdf=True)
+    _ = rod.Sdf.load(sdf=urdf_path.read_text(), is_urdf=True)
+
+    # Load once again the urdf
+    rod_sdf = rod.Sdf.load(sdf=urdf_path, is_urdf=True)
+
+    # There should be only one model
+    assert len(rod_sdf.models()) == 1
+    assert rod_sdf.models()[0] == rod_sdf.model
+
+    # Note: when a URDF is loaded into ROD, it gets first converted to SDF by sdformat.
+    # This pre-processing might alter the URDF, especially if fixed joints are present.
+
+    # Load the model in iDynTree (w/o specifying the joints list)
+    idt_model_full = robot_descriptions.loaders.idyntree.load_robot_description(
+        description_name=robot.to_module_name(), joints_list=None
+    )
+
+    # Check the canonical link
+    assert rod_sdf.model.get_canonical_link() == idt_model_full.getLinkName(
+        idt_model_full.getDefaultBaseLink()
+    )
+
+    # Extract data from the ROD model
+    link_names = [l.name for l in rod_sdf.model.links()]
+    joint_names = [j.name for j in rod_sdf.model.joints()]
+    joint_names_dofs = [j.name for j in rod_sdf.model.joints() if j.type != "fixed"]
+
+    # Remove the world joint if the model is fixed-base
+    if rod_sdf.model.is_fixed_base():
+        world_joints = [
+            j.name
+            for j in rod_sdf.model.joints()
+            if j.type == "fixed" and j.parent == "world"
+        ]
+        assert len(world_joints) == 1
+        _ = joint_names.pop(joint_names.index(world_joints[0]))
+        assert _ == world_joints[0]
+
+    # New sdformat versions, after lumping fixed joints, create a new frame called
+    # "<removed_fake_link>_fixed_joint"
+    frame_names = [
+        f.name for f in rod_sdf.model.frames() if not f.name.endswith("_fixed_joint")
+    ]
+
+    # Check the number of DoFs (all non-fixed joints)
+    assert len(joint_names_dofs) == idt_model_full.getNrOfDOFs()
+
+    link_names_idt = [
+        idt_model_full.getLinkName(idx) for idx in range(idt_model_full.getNrOfLinks())
+    ]
+
+    joint_names_idt = [
+        idt_model_full.getJointName(idx)
+        for idx in range(idt_model_full.getNrOfJoints())
+    ]
+
+    # Note: iDynTree also includes sensor frames here, while ROD does not
+    frame_names_idt = [
+        idt_model_full.getFrameName(idx)
+        for idx in range(idt_model_full.getNrOfLinks(), idt_model_full.getNrOfFrames())
+    ]
+
+    assert set(link_names_idt) == set(link_names)
+    assert set(joint_names_idt) == set(joint_names)
+    assert set(frame_names) - set(frame_names_idt) == set()
+
+    total_mass = sum([l.inertial.mass for l in rod_sdf.model.links()])
+    assert total_mass == pytest.approx(idt_model_full.getTotalMass())

--- a/tests/utils_models.py
+++ b/tests/utils_models.py
@@ -1,0 +1,60 @@
+import enum
+import importlib
+import pathlib
+from typing import Union
+
+
+class Robot(enum.IntEnum):
+    Hyq = enum.auto()
+    iCub = enum.auto()
+    Ur10 = enum.auto()
+    Baxter = enum.auto()
+    Cassie = enum.auto()
+    Fetch = enum.auto()
+    AtlasV4 = enum.auto()
+    Laikago = enum.auto()
+    AnymalC = enum.auto()
+    Ergocub = enum.auto()
+    Talos = enum.auto()
+    Valkyrie = enum.auto()
+    DoublePendulum = enum.auto()
+    SimpleHumanoid = enum.auto()
+
+    def to_module_name(self) -> str:
+        """"""
+
+        if self is Robot.iCub:
+            return "icub_description"
+
+        # Convert the camelcase robot name to snakecase
+        name_sc = "".join(
+            ["_" + c.lower() if c.isupper() else c for c in self.name]
+        ).lstrip("_")
+
+        return f"{name_sc}_description"
+
+
+class ModelFactory:
+    """Factory class providing URDF files used by the tests."""
+
+    @staticmethod
+    def get_model_description(robot: Union[Robot, str]) -> pathlib.Path:
+        """
+        Get the URDF file of different robots.
+
+        Args:
+            robot: Robot name of the desired URDF file.
+
+        Returns:
+            Path to the URDF file of the robot.
+        """
+
+        module_name = robot if isinstance(robot, str) else robot.to_module_name()
+        module = importlib.import_module(f"robot_descriptions.{module_name}")
+
+        urdf_path = pathlib.Path(module.URDF_PATH)
+
+        if not urdf_path.is_file():
+            raise FileExistsError(f"URDF file '{urdf_path}' does not exist")
+
+        return urdf_path


### PR DESCRIPTION
This PR adds a first test in which `rod` is used to load URDF models from [robot-descriptions/robot_descriptions.py](https://github.com/robot-descriptions/robot_descriptions.py) and check the read information against [robotology/idyntree](https://github.com/robotology/idyntree/).

Note that `rod` has not direct support of URDF, we only support SDF. As a workaround, we expect to find `ign sdf|gz sdf` installed system-wise, and call `sdformat` to convert the URDF to SDF before parsing it with `rod`.

This processing has some side effect. In particular, the URDF model is processed by sdformat and the resulting SDF might differ particularly regarding the lumping logic of links attached through fixed joints.

The test uses iDynTree as ground truth. Similarly, also iDynTree performs link lumping, but it is not 100% compatible with the logic of sdformat. In particular, this PR considers common robot models that work in iDynTree. There are models in which I get the following mismatches:

- Sensor frames of some model do not become frames in idyntree and still show as links.
- When there's a fixed joint + fake link attached to the base link, idyntree lumps the two base frames keeping a different link than sdformat. Therefore, the considered base frame and the removed link converted to frame are flipped.

The models that do not work will possibly get fixed in the future. 

The test runs in two different envs:

- Ubuntu 22.04 installing Gazebo Classic from `apt` and all the rest from PyPI.
- Ubuntu, macOS, and Windows installing all dependencies with `conda`.

On Windows, the `gz sdf` command line we use for the URDF to SDF conversion does not work for some reason, the `pytest` suite is disabled on this OS. cc @traversaro 

<details>
<summary>Windows error</summary>

```
        if cp.returncode != 0:
            msg = f"Failed to find 'sdf' command part of {executable} installation"
           raise RuntimeError(msg)
           RuntimeError: Failed to find 'sdf' command part of C:\Miniconda3\envs\test\Library\bin\gz.BAT installation
```

</details>