### PR TITLE
Add support of colors when exporting to URDF geometries with material element

### DIFF
--- a/src/rod/builder/primitive_builder.py
+++ b/src/rod/builder/primitive_builder.py
@@ -14,10 +14,10 @@ class PrimitiveBuilder(abc.ABC):
     name: str
     mass: float
 
-    element: Union[
-        rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual
-    ] = dataclasses.field(
-        default=None, init=False, repr=False, hash=False, compare=False
+    element: Union[rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual] = (
+        dataclasses.field(
+            default=None, init=False, repr=False, hash=False, compare=False
+        )
     )
 
     def build(

--- a/src/rod/pretty_printer.py
+++ b/src/rod/pretty_printer.py
@@ -21,9 +21,11 @@ class DataclassPrettyPrinter(abc.ABC):
         spacing_level_up = spacing * (level - 1)
 
         list_str = [
-            DataclassPrettyPrinter.dataclass_to_str(obj=el, level=level + 1)
-            if dataclasses.is_dataclass(el)
-            else str(el)
+            (
+                DataclassPrettyPrinter.dataclass_to_str(obj=el, level=level + 1)
+                if dataclasses.is_dataclass(el)
+                else str(el)
+            )
             for el in obj
         ]
 

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -11,7 +11,8 @@ from rod.kinematics.tree_transforms import TreeTransforms
 
 
 class UrdfExporter(abc.ABC):
-    SUPPORTED_SDF_JOINT_TYPES = {"revolute", "continuous", "prismatic", "fixed"}
+
+    SupportedSdfJointTypes = {"revolute", "continuous", "prismatic", "fixed"}
 
     DefaultMaterial = {
         "@name": "default_material",
@@ -351,7 +352,7 @@ class UrdfExporter(abc.ABC):
                         # safety_controller: does not have any SDF corresponding element
                     }
                     for j in model.joints()
-                    if j.type in UrdfExporter.SUPPORTED_SDF_JOINT_TYPES
+                    if j.type in UrdfExporter.SupportedSdfJointTypes
                 ]
                 # Add the extra joints resulting from the frame->link conversion
                 + extra_joints_from_frames,

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -23,7 +23,7 @@ class UrdfExporter(abc.ABC):
 
     @staticmethod
     def sdf_to_urdf_string(
-        sdf: rod.Sdf,
+        sdf: rod.Sdf | rod.Model,
         pretty: bool = False,
         indent: str = "  ",
         gazebo_preserve_fixed_joints: Union[bool, List[str]] = False,
@@ -31,11 +31,11 @@ class UrdfExporter(abc.ABC):
         # Operate on a copy of the sdf object
         sdf = copy.deepcopy(sdf)
 
-        if len(sdf.models()) > 1:
+        if isinstance(sdf, rod.Sdf) and len(sdf.models()) > 1:
             raise RuntimeError("URDF only supports one robot element")
 
         # Get the model
-        model = sdf.models()[0]
+        model = sdf if isinstance(sdf, rod.Model) else sdf.models()[0]
 
         # Remove all poses that could be assumed being implicit
         model.resolve_frames(is_top_level=True, explicit_frames=False)


### PR DESCRIPTION
We use the [`//visual/material/diffuse`](http://sdformat.org/spec?ver=1.11&elem=material#material_diffuse) SDF element and convert it into the [`visual/material/color@rgba`](http://wiki.ros.org/urdf/XML/link#Elements) URDF attribute.

Note that other material properties of SDF are ignored. We cannot work around it since the material properties of URDF are more limited than those of SDF.

Additional information on SDF materials:
- http://sdformat.org/tutorials?tut=spec_materials