### PR TITLE
Update CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,13 +9,13 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Execute a "nightly" build at 2 AM UTC
-    - cron:  '0 2 * * *'
+    - cron:  "0 2 * * *"
 
 jobs:
 
   package:
     name: Package the project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.*"
 
       - name: Install Python tools
         run: pip install build twine
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-latest
           - macos-latest
           - windows-latest
         type:
@@ -104,8 +104,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gazebo
-          # Remove following line as soon as iDynTree is available on Python 3.11:
-          pip install --pre idyntree
 
       - name: Install conda dependencies
         if: matrix.type == 'conda'
@@ -156,8 +154,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: test
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -114,6 +114,7 @@ jobs:
             mashumaro \
             numpy \
             packaging \
+            resolve-robotics-uri-py \
             scipy \
             xmltodict \
             black \

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,6 +1,7 @@
 name: Python CI/CD
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
   release:
@@ -9,7 +10,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Execute a "nightly" build at 2 AM UTC
-    - cron:  "0 2 * * *"
+    - cron: "0 2 * * *"
 
 jobs:
 


### PR DESCRIPTION
For reason that I don't understand it no longer gets triggered. @traversaro any clue?

Furthermore:

- Add in CI new `resolve-robotics-uri-py` dependency that was missing in #28. I didn't notice it because the CI/CD didn't start.
- Add `workflow_dispatch`.