### PR TITLE
Improve model handling speed

### DIFF
--- a/src/rod/__init__.py
+++ b/src/rod/__init__.py
@@ -115,9 +115,9 @@ def check_compatible_sdformat(specification_version: str) -> None:
 
     if not GazeboHelper.has_gazebo():
         return
-    else:
-        cmdline = GazeboHelper.get_gazebo_executable()
-        logging.info(f"Calling sdformat through '{cmdline} sdf'")
+
+    cmdline = GazeboHelper.get_gazebo_executable()
+    logging.info(f"Calling sdformat through '{cmdline} sdf'")
 
     output_sdf_version = packaging.version.Version(
         xmltodict.parse(

--- a/src/rod/builder/primitive_builder.py
+++ b/src/rod/builder/primitive_builder.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import abc
 import dataclasses
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -14,7 +16,7 @@ class PrimitiveBuilder(abc.ABC):
     name: str
     mass: float
 
-    element: Union[rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual] = (
+    element: rod.Model | rod.Link | rod.Inertial | rod.Collision | rod.Visual = (
         dataclasses.field(
             default=None, init=False, repr=False, hash=False, compare=False
         )
@@ -22,7 +24,7 @@ class PrimitiveBuilder(abc.ABC):
 
     def build(
         self,
-    ) -> Union[rod.Model, rod.Link, rod.Inertial, rod.Collision, rod.Visual]:
+    ) -> rod.Model | rod.Link | rod.Inertial | rod.Collision | rod.Visual:
         return self.element
 
     # ================
@@ -43,9 +45,9 @@ class PrimitiveBuilder(abc.ABC):
 
     def build_model(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
-    ) -> "PrimitiveBuilder":
+        name: str | None = None,
+        pose: rod.Pose | None = None,
+    ) -> PrimitiveBuilder:
         self._check_element()
 
         self.element = self._model(name=name, pose=pose)
@@ -54,16 +56,16 @@ class PrimitiveBuilder(abc.ABC):
 
     def build_link(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
-    ) -> "PrimitiveBuilder":
+        name: str | None = None,
+        pose: rod.Pose | None = None,
+    ) -> PrimitiveBuilder:
         self._check_element()
 
         self.element = self._link(name=name, pose=pose)
 
         return self
 
-    def build_inertial(self, pose: Optional[rod.Pose] = None) -> "PrimitiveBuilder":
+    def build_inertial(self, pose: rod.Pose | None = None) -> PrimitiveBuilder:
         self._check_element()
 
         self.element = self._inertial(pose=pose)
@@ -72,9 +74,9 @@ class PrimitiveBuilder(abc.ABC):
 
     def build_visual(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
-    ) -> "PrimitiveBuilder":
+        name: str | None = None,
+        pose: rod.Pose | None = None,
+    ) -> PrimitiveBuilder:
         self._check_element()
 
         self.element = self._visual(name=name, pose=pose)
@@ -83,9 +85,9 @@ class PrimitiveBuilder(abc.ABC):
 
     def build_collision(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
-    ) -> "PrimitiveBuilder":
+        name: str | None = None,
+        pose: rod.Pose | None = None,
+    ) -> PrimitiveBuilder:
         self._check_element()
 
         self.element = self._collision(name=name, pose=pose)
@@ -98,10 +100,10 @@ class PrimitiveBuilder(abc.ABC):
 
     def add_link(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
-        link: Optional[rod.Link] = None,
-    ) -> "PrimitiveBuilder":
+        name: str | None = None,
+        pose: rod.Pose | None = None,
+        link: rod.Link | None = None,
+    ) -> PrimitiveBuilder:
         if not isinstance(self.element, rod.Model):
             raise ValueError(type(self.element))
 
@@ -116,9 +118,9 @@ class PrimitiveBuilder(abc.ABC):
 
     def add_inertial(
         self,
-        pose: Optional[rod.Pose] = None,
-        inertial: Optional[rod.Inertial] = None,
-    ) -> "PrimitiveBuilder":
+        pose: rod.Pose | None = None,
+        inertial: rod.Inertial | None = None,
+    ) -> PrimitiveBuilder:
         if not isinstance(self.element, (rod.Model, rod.Link)):
             raise ValueError(type(self.element))
 
@@ -144,11 +146,11 @@ class PrimitiveBuilder(abc.ABC):
 
     def add_visual(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         use_inertial_pose: bool = True,
-        pose: Optional[rod.Pose] = None,
-        visual: Optional[rod.Visual] = None,
-    ) -> "PrimitiveBuilder":
+        pose: rod.Pose | None = None,
+        visual: rod.Visual | None = None,
+    ) -> PrimitiveBuilder:
         if not isinstance(self.element, (rod.Model, rod.Link)):
             raise ValueError(type(self.element))
 
@@ -180,11 +182,11 @@ class PrimitiveBuilder(abc.ABC):
 
     def add_collision(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         use_inertial_pose: bool = True,
-        pose: Optional[rod.Pose] = None,
-        collision: Optional[rod.Collision] = None,
-    ) -> "PrimitiveBuilder":
+        pose: rod.Pose | None = None,
+        collision: rod.Collision | None = None,
+    ) -> PrimitiveBuilder:
         if not isinstance(self.element, (rod.Model, rod.Link)):
             raise ValueError(type(self.element))
 
@@ -224,8 +226,8 @@ class PrimitiveBuilder(abc.ABC):
 
     def _model(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
+        name: str | None = None,
+        pose: rod.Pose | None = None,
     ) -> rod.Model:
         name = name if name is not None else self.name
         logging.debug(f"Building model '{name}'")
@@ -240,15 +242,15 @@ class PrimitiveBuilder(abc.ABC):
 
     def _link(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
+        name: str | None = None,
+        pose: rod.Pose | None = None,
     ) -> rod.Link:
         return rod.Link(
             name=name if name is not None else f"{self.name}_link",
             pose=pose,
         )
 
-    def _inertial(self, pose: Optional[rod.Pose] = None) -> rod.Inertial:
+    def _inertial(self, pose: rod.Pose | None = None) -> rod.Inertial:
         return rod.Inertial(
             pose=pose,
             mass=self.mass,
@@ -257,8 +259,8 @@ class PrimitiveBuilder(abc.ABC):
 
     def _visual(
         self,
-        name: Optional[str] = None,
-        pose: Optional[rod.Pose] = None,
+        name: str | None = None,
+        pose: rod.Pose | None = None,
     ) -> rod.Visual:
         name = name if name is not None else f"{self.name}_visual"
 
@@ -271,7 +273,7 @@ class PrimitiveBuilder(abc.ABC):
     def _collision(
         self,
         name: Optional[str],
-        pose: Optional[rod.Pose] = None,
+        pose: rod.Pose | None = None,
     ) -> rod.Collision:
         name = name if name is not None else f"{self.name}_collision"
 
@@ -297,7 +299,7 @@ class PrimitiveBuilder(abc.ABC):
         relative_to: str = None,
         degrees: bool = None,
         rotation_format: str = None,
-    ) -> Optional[rod.Pose]:
+    ) -> rod.Pose | None:
         if pos is None and rpy is None:
             return rod.Pose.from_transform(transform=np.eye(4), relative_to=relative_to)
 

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -1,6 +1,5 @@
 import dataclasses
 import pathlib
-from typing import Union
 
 import trimesh
 from numpy.typing import NDArray
@@ -63,7 +62,7 @@ class CylinderBuilder(PrimitiveBuilder):
 
 @dataclasses.dataclass
 class MeshBuilder(PrimitiveBuilder):
-    mesh_path: Union[str, pathlib.Path]
+    mesh_path: str | pathlib.Path
     scale: NDArray
 
     def __post_init__(self) -> None:

--- a/src/rod/kinematics/kinematic_tree.py
+++ b/src/rod/kinematics/kinematic_tree.py
@@ -201,7 +201,7 @@ class KinematicTree(DirectedTree):
             new_base_node, additional_frames = KinematicTree.remove_edge(
                 edge=world_to_base_edge, keep_parent=False
             )
-            assert any([f.name() == TreeFrame.WORLD for f in additional_frames])
+            assert any(f.name() == TreeFrame.WORLD for f in additional_frames)
 
             # Replace the former base node with the new base node
             nodes_links_dict[new_base_node.name()] = new_base_node

--- a/src/rod/kinematics/kinematic_tree.py
+++ b/src/rod/kinematics/kinematic_tree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import dataclasses
 import functools
@@ -12,7 +14,7 @@ from rod.tree import DirectedTree, DirectedTreeNode, TreeEdge, TreeFrame
 
 @dataclasses.dataclass(frozen=True)
 class KinematicTree(DirectedTree):
-    model: "rod.Model"
+    model: rod.Model
 
     joints: List[TreeEdge] = dataclasses.field(default_factory=list)
     frames: List[TreeFrame] = dataclasses.field(default_factory=list)
@@ -46,7 +48,7 @@ class KinematicTree(DirectedTree):
         return [joint.name() for joint in self.joints]
 
     @staticmethod
-    def build(model: "rod.Model", is_top_level: bool = True) -> "KinematicTree":
+    def build(model: rod.Model, is_top_level: bool = True) -> KinematicTree:
         logging.debug(msg=f"Building kinematic tree of model '{model.name}'")
 
         if model.model is not None:

--- a/src/rod/kinematics/kinematic_tree.py
+++ b/src/rod/kinematics/kinematic_tree.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import functools
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Tuple
 
 import numpy as np
 

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -14,6 +14,7 @@ from rod.tree import TreeFrame
 @dataclasses.dataclass
 class TreeTransforms:
     kinematic_tree: KinematicTree = dataclasses.dataclass(init=False)
+    _transform_cache: dict[str, npt.NDArray] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def build(
@@ -31,6 +32,13 @@ class TreeTransforms:
         )
 
     def transform(self, name: str) -> npt.NDArray:
+        if name in self._transform_cache:
+            return self._transform_cache[name]
+
+        self._transform_cache[name] = self._compute_transform(name=name)
+        return self._transform_cache[name]
+
+    def _compute_transform(self, name: str) -> npt.NDArray:
         match name:
             case TreeFrame.WORLD:
 

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import dataclasses
 
@@ -14,9 +16,10 @@ class TreeTransforms:
     kinematic_tree: KinematicTree = dataclasses.dataclass(init=False)
 
     @staticmethod
-    def build(model: "rod.Model", is_top_level: bool = True) -> "TreeTransforms":
-
-        # Operate on a deep copy of the model to avoid side effects.
+    def build(
+        model: rod.Model,
+        is_top_level: bool = True,
+    ) -> TreeTransforms:
         model = copy.deepcopy(model)
 
         # Make sure that all elements have a pose attribute with explicit 'relative_to'.

--- a/src/rod/logging.py
+++ b/src/rod/logging.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-from typing import Union
 
 import coloredlogs
 
@@ -20,7 +19,7 @@ def _logger() -> logging.Logger:
     return logging.getLogger(name=LOGGER_NAME)
 
 
-def set_logging_level(level: Union[int, LoggingLevel] = LoggingLevel.WARNING):
+def set_logging_level(level: int | LoggingLevel = LoggingLevel.WARNING):
     if isinstance(level, int):
         level = LoggingLevel(level)
 

--- a/src/rod/pretty_printer.py
+++ b/src/rod/pretty_printer.py
@@ -30,7 +30,7 @@ class DataclassPrettyPrinter(abc.ABC):
         ]
 
         return (
-            f"[\n"
+            "[\n"
             + ",\n".join(f"{spacing_level}{el!s}" for el in list_str)
             + f",\n{spacing_level_up}]"
         )

--- a/src/rod/pretty_printer.py
+++ b/src/rod/pretty_printer.py
@@ -45,26 +45,27 @@ class DataclassPrettyPrinter(abc.ABC):
         for field in dataclasses.fields(obj):
             attr = getattr(obj, field.name)
 
-            if attr is None or attr == "":
-                continue
+            match attr:
+                case None | "":
+                    continue
 
-            elif isinstance(attr, list):
-                list_str = DataclassPrettyPrinter.list_to_string(
-                    obj=attr, level=level + 1
-                )
-                serialization += [(field.name, list_str)]
-                continue
+                case list():
+                    list_str = DataclassPrettyPrinter.list_to_string(
+                        obj=attr, level=level + 1
+                    )
+                    serialization += [(field.name, list_str)]
+                    continue
 
-            elif dataclasses.is_dataclass(attr):
-                dataclass_str = DataclassPrettyPrinter.dataclass_to_str(
-                    obj=attr, level=level + 1
-                )
-                serialization += [(field.name, dataclass_str)]
-                continue
+                case _ if dataclasses.is_dataclass(attr):
+                    dataclass_str = DataclassPrettyPrinter.dataclass_to_str(
+                        obj=attr, level=level + 1
+                    )
+                    serialization += [(field.name, dataclass_str)]
+                    continue
 
-            else:
-                serialization += [(field.name, f"{attr!s}")]
-                continue
+                case _:
+                    serialization += [(field.name, f"{attr!s}")]
+                    continue
 
         spacing = " " * 4
         spacing_level = spacing * level

--- a/src/rod/sdf/element.py
+++ b/src/rod/sdf/element.py
@@ -37,7 +37,7 @@ class Element(mashumaro.mixins.dict.DataClassDictMixin, DataclassPrettyPrinter):
         false_vals = {"0", "False", "false"}
         assert data in true_vals.union(false_vals)
 
-        return True if data in true_vals else False
+        return data in true_vals
 
     @staticmethod
     def serialize_float(data: float) -> str:

--- a/src/rod/sdf/element.py
+++ b/src/rod/sdf/element.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import mashumaro.config
 import mashumaro.mixins.dict
@@ -50,7 +50,7 @@ class Element(mashumaro.mixins.dict.DataClassDictMixin, DataclassPrettyPrinter):
         return " ".join(np.array(data, dtype=str))
 
     @staticmethod
-    def deserialize_list(data: str, length: Optional[int] = None) -> List[float]:
+    def deserialize_list(data: str, length: int | None = None) -> List[float]:
         assert isinstance(data, str)
         array = np.atleast_1d(np.array(data.split(sep=" "), dtype=float).squeeze())
 

--- a/src/rod/sdf/link.py
+++ b/src/rod/sdf/link.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import mashumaro
 import numpy as np
@@ -73,11 +73,9 @@ class Link(Element):
 
     inertial: Optional[Inertial] = dataclasses.field(default=None)
 
-    visual: Optional[Union[Visual, List[Visual]]] = dataclasses.field(default=None)
+    visual: Optional[Visual | List[Visual]] = dataclasses.field(default=None)
 
-    collision: Optional[Union[Collision, List[Collision]]] = dataclasses.field(
-        default=None
-    )
+    collision: Optional[Collision | List[Collision]] = dataclasses.field(default=None)
 
     gravity: Optional[bool] = dataclasses.field(
         default=None,

--- a/src/rod/sdf/model.py
+++ b/src/rod/sdf/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from typing import List, Optional, Union
 
@@ -155,7 +157,7 @@ class Model(Element):
 
     def switch_frame_convention(
         self,
-        frame_convention: "rod.FrameConvention",
+        frame_convention: rod.FrameConvention,
         is_top_level: bool = True,
         explicit_frames: bool = True,
         attach_frames_to_links: bool = True,

--- a/src/rod/sdf/model.py
+++ b/src/rod/sdf/model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import mashumaro
 
@@ -56,13 +56,13 @@ class Model(Element):
 
     pose: Optional[Pose] = dataclasses.field(default=None)
 
-    model: Optional[Union["Model", List["Model"]]] = dataclasses.field(default=None)
+    model: Optional[Model | List[Model]] = dataclasses.field(default=None)
 
-    frame: Optional[Union[Frame, List[Frame]]] = dataclasses.field(default=None)
+    frame: Optional[Frame | List[Frame]] = dataclasses.field(default=None)
 
-    link: Optional[Union[Link, List[Link]]] = dataclasses.field(default=None)
+    link: Optional[Link | List[Link]] = dataclasses.field(default=None)
 
-    joint: Optional[Union[Joint, List[Joint]]] = dataclasses.field(default=None)
+    joint: Optional[Joint | List[Joint]] = dataclasses.field(default=None)
 
     def is_fixed_base(self) -> bool:
         joints_having_world_parent = [j for j in self.joints() if j.parent == "world"]
@@ -82,7 +82,7 @@ class Model(Element):
 
         return self.links()[0].name
 
-    def models(self) -> List["Model"]:
+    def models(self) -> List[Model]:
         if self.model is None:
             return []
 

--- a/src/rod/sdf/sdf.py
+++ b/src/rod/sdf/sdf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import os
 import pathlib
@@ -44,7 +46,7 @@ class Sdf(Element):
         return self.model
 
     @staticmethod
-    def load(sdf: Union[pathlib.Path, str], is_urdf: Optional[bool] = None) -> "Sdf":
+    def load(sdf: Union[pathlib.Path, str], is_urdf: Optional[bool] = None) -> Sdf:
         """
         Load an SDF resource.
 

--- a/src/rod/sdf/sdf.py
+++ b/src/rod/sdf/sdf.py
@@ -82,7 +82,7 @@ class Sdf(Element):
             and len(sdf) <= MAX_PATH
             and pathlib.Path(sdf).is_file()
         ):
-            sdf_string = pathlib.Path(sdf).read_text()
+            sdf_string = pathlib.Path(sdf).read_text(encoding="utf-8")
             is_urdf = (
                 is_urdf if is_urdf is not None else pathlib.Path(sdf).suffix == ".urdf"
             )

--- a/src/rod/sdf/sdf.py
+++ b/src/rod/sdf/sdf.py
@@ -101,8 +101,8 @@ class Sdf(Element):
         # Parse the SDF to dict
         try:
             xml_dict = xmltodict.parse(xml_input=sdf_string)
-        except Exception:
-            raise ValueError("Failed to parse 'sdf' argument")
+        except Exception as exc:
+            raise exc("Failed to parse 'sdf' argument")
 
         # Look for the top-level <sdf> element
         try:

--- a/src/rod/sdf/sdf.py
+++ b/src/rod/sdf/sdf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import pathlib
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import mashumaro
 import packaging.specifiers
@@ -21,9 +21,9 @@ from .world import World
 class Sdf(Element):
     version: str = dataclasses.field(metadata=mashumaro.field_options(alias="@version"))
 
-    world: Optional[Union[World, List[World]]] = dataclasses.field(default=None)
+    world: Optional[World | List[World]] = dataclasses.field(default=None)
 
-    model: Optional[Union[Model, List[Model]]] = dataclasses.field(default=None)
+    model: Optional[Model | List[Model]] = dataclasses.field(default=None)
 
     def worlds(self) -> List[World]:
         if self.world is None:
@@ -46,7 +46,7 @@ class Sdf(Element):
         return self.model
 
     @staticmethod
-    def load(sdf: Union[pathlib.Path, str], is_urdf: Optional[bool] = None) -> Sdf:
+    def load(sdf: pathlib.Path | str, is_urdf: bool | None = None) -> Sdf:
         """
         Load an SDF resource.
 

--- a/src/rod/sdf/world.py
+++ b/src/rod/sdf/world.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import mashumaro
 
@@ -34,9 +34,9 @@ class World(Element):
 
     scene: Scene = dataclasses.field(default_factory=Scene)
 
-    model: Optional[Union[Model, List[Model]]] = dataclasses.field(default=None)
+    model: Optional[Model | List[Model]] = dataclasses.field(default=None)
 
-    frame: Optional[Union[Frame, List[Frame]]] = dataclasses.field(default=None)
+    frame: Optional[Frame | List[Frame]] = dataclasses.field(default=None)
 
     def models(self) -> List[Model]:
         if self.model is None:

--- a/src/rod/tree/directed_tree.py
+++ b/src/rod/tree/directed_tree.py
@@ -1,7 +1,7 @@
 import collections.abc
 import dataclasses
 import functools
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List
 
 from .tree_elements import DirectedTreeNode
 
@@ -33,7 +33,7 @@ class DirectedTree(collections.abc.Sequence):
     @staticmethod
     def breadth_first_search(
         root: DirectedTreeNode,
-        sort_children: Optional[Callable[[Any], Any]] = lambda node: node.name(),
+        sort_children: Callable[[Any], Any] | None = lambda node: node.name(),
     ) -> Iterable[DirectedTreeNode]:
         queue = [root]
 
@@ -69,8 +69,8 @@ class DirectedTree(collections.abc.Sequence):
         )
 
     def __getitem__(
-        self, key: Union[int, slice, str]
-    ) -> Union[DirectedTreeNode, List[DirectedTreeNode]]:
+        self, key: int | slice | str
+    ) -> DirectedTreeNode | List[DirectedTreeNode]:
         # Get the nodes' dictionary (already inserted in order following BFS)
         nodes_dict = self.nodes_dict
 
@@ -100,7 +100,7 @@ class DirectedTree(collections.abc.Sequence):
     def __reversed__(self) -> Iterable[DirectedTreeNode]:
         yield from reversed(self)
 
-    def __contains__(self, item: Union[str, DirectedTreeNode]) -> bool:
+    def __contains__(self, item: str | DirectedTreeNode) -> bool:
         if isinstance(item, str):
             return item in self.nodes_dict.keys()
 

--- a/src/rod/tree/tree_elements.py
+++ b/src/rod/tree/tree_elements.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-from typing import ClassVar, List, Optional, Union
+from typing import ClassVar, List, Optional
 
 import rod
 from rod import logging
@@ -90,7 +90,7 @@ class TreeFrame(TreeElement):
     WORLD: ClassVar[str] = "world"
     MODEL: ClassVar[str] = "__model__"
 
-    _source: Optional["rod.Frame"] = dataclasses.field(default=None, repr=False)
+    _source: Optional[rod.Frame] = dataclasses.field(default=None, repr=False)
 
     def name(self) -> str:
         return self._source.name
@@ -111,7 +111,7 @@ class TreeFrame(TreeElement):
     @staticmethod
     def from_node(
         node: DirectedTreeNode,
-        attached_to: Union[DirectedTreeNode, TreeFrame, TreeEdge] = None,
+        attached_to: DirectedTreeNode | TreeFrame | TreeEdge | None = None,
     ) -> TreeFrame:
         attached_to = attached_to if attached_to is not None else node.parent
 
@@ -130,7 +130,7 @@ class TreeFrame(TreeElement):
     @staticmethod
     def from_edge(
         edge: TreeEdge,
-        attached_to: Union[DirectedTreeNode, TreeFrame, TreeEdge] = None,
+        attached_to: DirectedTreeNode | TreeFrame | TreeEdge | None = None,
     ) -> TreeFrame:
         attached_to = attached_to if attached_to is not None else edge.parent
 

--- a/src/rod/tree/tree_elements.py
+++ b/src/rod/tree/tree_elements.py
@@ -34,16 +34,16 @@ class DirectedTreeNode(TreeElement):
     parent: Optional[DirectedTreeNode] = None
     children: List[DirectedTreeNode] = dataclasses.field(default_factory=list)
 
-    _source: Optional["rod.Link"] = dataclasses.field(default=None, repr=False)
+    _source: Optional[rod.Link] = dataclasses.field(default=None, repr=False)
 
     def name(self) -> str:
         return self._source.name
 
-    def pose(self) -> "rod.Pose":
+    def pose(self) -> rod.Pose:
         if self._source is not None and self._source.pose is not None:
             return self._source.pose
-        else:
-            return rod.Pose(relative_to="world")
+
+        return rod.Pose(relative_to="world")
 
     @property
     def tree_label(self) -> str:

--- a/src/rod/tree/tree_elements.py
+++ b/src/rod/tree/tree_elements.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import dataclasses
 from typing import ClassVar, List, Optional, Union
@@ -29,8 +31,8 @@ class TreeElement(abc.ABC):
 
 @dataclasses.dataclass(eq=False)
 class DirectedTreeNode(TreeElement):
-    parent: Optional["DirectedTreeNode"] = None
-    children: List["DirectedTreeNode"] = dataclasses.field(default_factory=list)
+    parent: Optional[DirectedTreeNode] = None
+    children: List[DirectedTreeNode] = dataclasses.field(default_factory=list)
 
     _source: Optional["rod.Link"] = dataclasses.field(default=None, repr=False)
 
@@ -69,7 +71,7 @@ class TreeEdge(TreeElement):
 
     _source: Optional[rod.Joint] = dataclasses.field(default=None, repr=False)
 
-    def pose(self) -> "rod.Pose":
+    def pose(self) -> rod.Pose:
         return self._source.pose
 
     def name(self) -> str:
@@ -109,8 +111,8 @@ class TreeFrame(TreeElement):
     @staticmethod
     def from_node(
         node: DirectedTreeNode,
-        attached_to: Union[DirectedTreeNode, "TreeFrame", TreeEdge] = None,
-    ) -> "TreeFrame":
+        attached_to: Union[DirectedTreeNode, TreeFrame, TreeEdge] = None,
+    ) -> TreeFrame:
         attached_to = attached_to if attached_to is not None else node.parent
 
         logging.debug(
@@ -128,8 +130,8 @@ class TreeFrame(TreeElement):
     @staticmethod
     def from_edge(
         edge: TreeEdge,
-        attached_to: Union[DirectedTreeNode, "TreeFrame", TreeEdge] = None,
-    ) -> "TreeFrame":
+        attached_to: Union[DirectedTreeNode, TreeFrame, TreeEdge] = None,
+    ) -> TreeFrame:
         attached_to = attached_to if attached_to is not None else edge.parent
 
         logging.debug(

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -1,7 +1,7 @@
 import abc
 import copy
 import dataclasses
-from typing import Any, ClassVar, Dict, List, Set, Union
+from typing import Any, ClassVar, Dict, List, Set
 
 import numpy as np
 import xmltodict
@@ -24,7 +24,7 @@ class UrdfExporter(abc.ABC):
     # Whether to inject additional `<gazebo>` elements in the resulting URDF
     # to preserve fixed joints in case of re-loading into sdformat.
     # If a list of strings is passed, only the listed fixed joints will be preserved.
-    gazebo_preserve_fixed_joints: Union[bool, List[str]] = False
+    gazebo_preserve_fixed_joints: bool | List[str] = False
 
     SupportedSdfJointTypes: ClassVar[Set[str]] = {
         "revolute",
@@ -42,10 +42,10 @@ class UrdfExporter(abc.ABC):
 
     @staticmethod
     def sdf_to_urdf_string(
-        sdf: Union[rod.Sdf, rod.Model],
+        sdf: rod.Sdf | rod.Model,
         pretty: bool = False,
         indent: str = "  ",
-        gazebo_preserve_fixed_joints: Union[bool, List[str]] = False,
+        gazebo_preserve_fixed_joints: bool | List[str] = False,
     ) -> str:
 
         msg = "This method is deprecated, please use '{}' instead."
@@ -57,7 +57,7 @@ class UrdfExporter(abc.ABC):
             gazebo_preserve_fixed_joints=gazebo_preserve_fixed_joints,
         ).to_urdf_string(sdf=sdf)
 
-    def to_urdf_string(self, sdf: Union[rod.Sdf, rod.Model]) -> str:
+    def to_urdf_string(self, sdf: rod.Sdf | rod.Model) -> str:
         """
         Convert an in-memory SDF model to a URDF string.
 

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -299,7 +299,7 @@ def find_parent_link_of_frame(frame: rod.Frame, model: rod.Model) -> str:
         case anchor if anchor in frames_dict:
             parent = frames_dict[frame.attached_to]
 
-        case frame if frame.attached in {model.name, "__model__"}:
+        case anchor if anchor in {model.name, "__model__"}:
             return model.get_canonical_link()
 
         case anchor if anchor in joints_dict:

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -15,7 +15,7 @@ class FrameConvention(enum.IntEnum):
 
 
 def switch_frame_convention(
-    model: "rod.Model",
+    model: rod.Model,
     frame_convention: FrameConvention,
     is_top_level: bool = True,
     attach_frames_to_links: bool = True,

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -70,102 +70,106 @@ def switch_frame_convention(
     # Define the default reference frames of the different elements
     # =============================================================
 
-    if frame_convention is FrameConvention.World:
+    match frame_convention:
+        case FrameConvention.World:
+            reference_frame_model = lambda m: "world"
+            reference_frame_links = lambda l: "world"
+            reference_frame_frames = lambda f: "world"
+            reference_frame_joints = lambda j: "world"
+            reference_frame_visuals = lambda v: "world"
+            reference_frame_inertials = lambda i, parent_link: "world"
+            reference_frame_collisions = lambda c: "world"
+            reference_frame_link_canonical = "world"
 
-        reference_frame_model = lambda m: "world"
-        reference_frame_links = lambda l: "world"
-        reference_frame_frames = lambda f: "world"
-        reference_frame_joints = lambda j: "world"
-        reference_frame_visuals = lambda v: "world"
-        reference_frame_inertials = lambda i, parent_link: "world"
-        reference_frame_collisions = lambda c: "world"
-        reference_frame_link_canonical = "world"
+        case FrameConvention.Model:
 
-    elif frame_convention is FrameConvention.Model:
-
-        reference_frame_model = lambda m: "world"
-        reference_frame_links = lambda l: "__model__"
-        reference_frame_frames = lambda f: "__model__"
-        reference_frame_joints = lambda j: "__model__"
-        reference_frame_visuals = lambda v: "__model__"
-        reference_frame_inertials = lambda i, parent_link: "__model__"
-        reference_frame_collisions = lambda c: "__model__"
-        reference_frame_link_canonical = "__model__"
-
-    elif frame_convention is FrameConvention.Sdf:
-
-        visual_name_to_parent_link = {
-            visual_name: parent_link
-            for d in [{v.name: link for v in link.visuals()} for link in model.links()]
-            for visual_name, parent_link in d.items()
-        }
-
-        collision_name_to_parent_link = {
-            collision_name: parent_link
-            for d in [
-                {c.name: link for c in link.collisions()} for link in model.links()
-            ]
-            for collision_name, parent_link in d.items()
-        }
-
-        reference_frame_model = lambda m: "world"
-        reference_frame_links = lambda l: "__model__"
-        reference_frame_frames = lambda f: f.attached_to
-        reference_frame_joints = lambda j: joint.child
-        reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
-        reference_frame_inertials = lambda i, parent_link: parent_link.name
-        reference_frame_collisions = lambda c: collision_name_to_parent_link[
-            c.name
-        ].name
-        reference_frame_link_canonical = "__model__"
-
-    elif frame_convention is FrameConvention.Urdf:
-
-        visual_name_to_parent_link = {
-            visual_name: parent_link
-            for d in [{v.name: link for v in link.visuals()} for link in model.links()]
-            for visual_name, parent_link in d.items()
-        }
-
-        collision_name_to_parent_link = {
-            collision_name: parent_link
-            for d in [
-                {c.name: link for c in link.collisions()} for link in model.links()
-            ]
-            for collision_name, parent_link in d.items()
-        }
-
-        link_name_to_parent_joint_names = defaultdict(list)
-
-        for j in model.joints():
-            if j.child != model.get_canonical_link():
-                link_name_to_parent_joint_names[j.child].append(j.name)
-            else:
-                # The pose of the canonical link is used to define the origin of
-                # the URDF joint connecting the world to the robot
-                assert model.is_fixed_base()
-                link_name_to_parent_joint_names[j.child].append("world")
-
-        reference_frame_model = lambda m: "world"
-        reference_frame_links = lambda l: link_name_to_parent_joint_names[l.name][0]
-        reference_frame_frames = lambda f: f.attached_to
-        reference_frame_joints = lambda j: j.parent
-        reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
-        reference_frame_inertials = lambda i, parent_link: parent_link.name
-        reference_frame_collisions = lambda c: collision_name_to_parent_link[
-            c.name
-        ].name
-
-        if model.is_fixed_base():
-            canonical_link = {l.name: l for l in model.links()}[
-                model.get_canonical_link()
-            ]
-            reference_frame_link_canonical = reference_frame_links(l=canonical_link)
-        else:
+            reference_frame_model = lambda m: "world"
+            reference_frame_links = lambda l: "__model__"
+            reference_frame_frames = lambda f: "__model__"
+            reference_frame_joints = lambda j: "__model__"
+            reference_frame_visuals = lambda v: "__model__"
+            reference_frame_inertials = lambda i, parent_link: "__model__"
+            reference_frame_collisions = lambda c: "__model__"
             reference_frame_link_canonical = "__model__"
 
-    else:
-        raise ValueError(frame_convention)
+        case FrameConvention.Sdf:
+
+            visual_name_to_parent_link = {
+                visual_name: parent_link
+                for d in [
+                    {v.name: link for v in link.visuals()} for link in model.links()
+                ]
+                for visual_name, parent_link in d.items()
+            }
+
+            collision_name_to_parent_link = {
+                collision_name: parent_link
+                for d in [
+                    {c.name: link for c in link.collisions()} for link in model.links()
+                ]
+                for collision_name, parent_link in d.items()
+            }
+
+            reference_frame_model = lambda m: "world"
+            reference_frame_links = lambda l: "__model__"
+            reference_frame_frames = lambda f: f.attached_to
+            reference_frame_joints = lambda j: joint.child
+            reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
+            reference_frame_inertials = lambda i, parent_link: parent_link.name
+            reference_frame_collisions = lambda c: collision_name_to_parent_link[
+                c.name
+            ].name
+            reference_frame_link_canonical = "__model__"
+
+        case FrameConvention.Urdf:
+
+            visual_name_to_parent_link = {
+                visual_name: parent_link
+                for d in [
+                    {v.name: link for v in link.visuals()} for link in model.links()
+                ]
+                for visual_name, parent_link in d.items()
+            }
+
+            collision_name_to_parent_link = {
+                collision_name: parent_link
+                for d in [
+                    {c.name: link for c in link.collisions()} for link in model.links()
+                ]
+                for collision_name, parent_link in d.items()
+            }
+
+            link_name_to_parent_joint_names = defaultdict(list)
+
+            for j in model.joints():
+                if j.child != model.get_canonical_link():
+                    link_name_to_parent_joint_names[j.child].append(j.name)
+                else:
+                    # The pose of the canonical link is used to define the origin of
+                    # the URDF joint connecting the world to the robot
+                    assert model.is_fixed_base()
+                    link_name_to_parent_joint_names[j.child].append("world")
+
+            reference_frame_model = lambda m: "world"
+            reference_frame_links = lambda l: link_name_to_parent_joint_names[l.name][0]
+            reference_frame_frames = lambda f: f.attached_to
+            reference_frame_joints = lambda j: j.parent
+            reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
+            reference_frame_inertials = lambda i, parent_link: parent_link.name
+            reference_frame_collisions = lambda c: collision_name_to_parent_link[
+                c.name
+            ].name
+
+            if model.is_fixed_base():
+                canonical_link = {l.name: l for l in model.links()}[
+                    model.get_canonical_link()
+                ]
+                reference_frame_link_canonical = reference_frame_links(l=canonical_link)
+            else:
+                reference_frame_link_canonical = "__model__"
+
+        case _:
+            raise ValueError(frame_convention)
 
     # =========================================
     # Process the reference frames of the model
@@ -288,33 +292,37 @@ def find_parent_link_of_frame(frame: rod.Frame, model: rod.Model) -> str:
 
     assert isinstance(frame, rod.Frame)
 
-    if frame.attached_to in links_dict:
-        parent = links_dict[frame.attached_to]
+    match frame.attached_to:
+        case anchor if anchor in links_dict:
+            parent = links_dict[frame.attached_to]
 
-    elif frame.attached_to in frames_dict:
-        parent = frames_dict[frame.attached_to]
+        case anchor if anchor in frames_dict:
+            parent = frames_dict[frame.attached_to]
 
-    elif frame.attached in {model.name, "__model__"}:
-        return model.get_canonical_link()
+        case frame if frame.attached in {model.name, "__model__"}:
+            return model.get_canonical_link()
 
-    elif frame.attached_to in joints_dict:
-        raise ValueError("Frames cannot be attached to joints")
+        case anchor if anchor in joints_dict:
+            raise ValueError("Frames cannot be attached to joints")
 
-    elif frame.attached_to in sub_models_dict:
-        raise RuntimeError("Model composition not yet supported")
+        case anchor if anchor in sub_models_dict:
+            raise RuntimeError("Model composition not yet supported")
 
-    else:
-        raise RuntimeError(f"Failed to find element with name '{frame.attached_to}'")
+        case _:
+            raise RuntimeError(
+                f"Failed to find element with name '{frame.attached_to}'"
+            )
 
     # At this point, the parent is either a link or another frame.
     assert isinstance(parent, (rod.Link, rod.Frame))
 
-    # If the parent is a link, can stop searching.
-    if isinstance(parent, rod.Link):
-        return parent.name
+    match parent:
+        # If the parent is a link, can stop searching.
+        case parent if isinstance(parent, rod.Link):
+            return parent.name
 
-    # If the parent is another frame, keep looking for the parent link.
-    if isinstance(parent, rod.Frame):
-        return find_parent_link_of_frame(frame=parent, model=model)
+        # If the parent is another frame, keep looking for the parent link.
+        case parent if isinstance(parent, rod.Frame):
+            return find_parent_link_of_frame(frame=parent, model=model)
 
     raise RuntimeError("This recursive function should never arrive here.")

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -46,7 +46,7 @@ class GazeboHelper:
         try:
             _ = GazeboHelper.get_gazebo_executable()
             return True
-        except:
+        except Exception:
             return False
 
     @staticmethod
@@ -108,10 +108,11 @@ class GazeboHelper:
                     text=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
+                    check=True,
                 )
             except subprocess.CalledProcessError as e:
-                if cp.returncode != 0:
-                    print(cp.stdout)
+                if e.returncode != 0:
+                    print(e.stdout)
                     raise RuntimeError(
                         "Failed to process the input with sdformat"
                     ) from e

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -99,6 +99,7 @@ class GazeboHelper:
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                check=True,
             )
 
         if cp.returncode != 0:

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -7,8 +7,13 @@ from typing import Union
 
 
 class GazeboHelper:
-    @staticmethod
-    def get_gazebo_executable() -> pathlib.Path:
+    _cached_executable: pathlib.Path = None
+
+    @classmethod
+    def get_gazebo_executable(cls) -> pathlib.Path:
+        if cls._cached_executable is not None:
+            return cls._cached_executable
+
         gz = shutil.which("gz")
         ign = shutil.which("ign")
 
@@ -25,13 +30,17 @@ class GazeboHelper:
             raise TypeError(executable)
 
         # Check if the sdf plugin of the simulator is installed
-        cp = subprocess.run([executable, "sdf", "--help"], capture_output=True)
-
-        if cp.returncode != 0:
+        try:
+            subprocess.run(
+                [executable, "sdf", "--help"], check=True, capture_output=True
+            )
+        except subprocess.CalledProcessError as e:
             msg = f"Failed to find 'sdf' command part of {executable} installation"
-            raise RuntimeError(msg)
+            raise RuntimeError(msg) from e
 
-        return executable
+        cls._cached_executable = executable
+
+        return cls._cached_executable
 
     @staticmethod
     def has_gazebo() -> bool:
@@ -94,17 +103,19 @@ class GazeboHelper:
                 fp.write(model_description_string)
                 fp.close()
 
-            cp = subprocess.run(
-                [str(gazebo_executable), "sdf", "-p", fp.name],
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=True,
-            )
-
-        if cp.returncode != 0:
-            print(cp.stdout)
-            raise RuntimeError("Failed to process the input with sdformat")
+            try:
+                cp = subprocess.run(
+                    [str(gazebo_executable), "sdf", "-p", fp.name],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+            except subprocess.CalledProcessError as e:
+                if cp.returncode != 0:
+                    print(cp.stdout)
+                    raise RuntimeError(
+                        "Failed to process the input with sdformat"
+                    ) from e
 
         # Get the resulting SDF string
         sdf_string = cp.stdout

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -3,7 +3,6 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
-from typing import Union
 
 
 class GazeboHelper:
@@ -52,7 +51,7 @@ class GazeboHelper:
 
     @staticmethod
     def process_model_description_with_sdformat(
-        model_description: Union[str, pathlib.Path]
+        model_description: str | pathlib.Path,
     ) -> str:
         # =============================
         # Select the correct input type

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -65,7 +65,9 @@ class GazeboHelper:
             and len(model_description) <= MAX_PATH
             and pathlib.Path(model_description).is_file()
         ):
-            model_description_string = pathlib.Path(model_description).read_text()
+            model_description_string = pathlib.Path(model_description).read_text(
+                encoding="utf-8"
+            )
 
         # Finally, it must be a SDF/URDF string
         else:

--- a/src/rod/utils/resolve_frames.py
+++ b/src/rod/utils/resolve_frames.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import List, Union
+from typing import List
 
 import numpy as np
 
@@ -10,7 +10,7 @@ from rod.sdf.element import Element
 
 
 def update_element_with_pose(
-    element: Element, default_relative_to: Union[str, List[str]], explicit_frames: bool
+    element: Element, default_relative_to: str | List[str], explicit_frames: bool
 ) -> None:
     if not hasattr(element, "pose"):
         raise ValueError("The input element has no 'pose' attribute")

--- a/src/rod/utils/resolve_frames.py
+++ b/src/rod/utils/resolve_frames.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import List, Union
 
@@ -52,7 +54,7 @@ def update_element_with_pose(
 
 
 def resolve_model_frames(
-    model: "rod.Model", is_top_level: bool = True, explicit_frames: bool = True
+    model: rod.Model, is_top_level: bool = True, explicit_frames: bool = True
 ) -> None:
     # Close the helper for compactness
     update_element = functools.partial(

--- a/src/rod/utils/resolve_uris.py
+++ b/src/rod/utils/resolve_uris.py
@@ -11,7 +11,7 @@ def resolve_local_uri(uri: str) -> pathlib.Path:
 
     try:
         return resolve_robotics_uri_py.resolve_robotics_uri(uri=uri)
-    except:
+    except FileNotFoundError:
         pass
 
     # Remove the prefix of the URI

--- a/tests/utils_models.py
+++ b/tests/utils_models.py
@@ -1,7 +1,6 @@
 import enum
 import importlib
 import pathlib
-from typing import Union
 
 
 class Robot(enum.IntEnum):
@@ -38,7 +37,7 @@ class ModelFactory:
     """Factory class providing URDF files used by the tests."""
 
     @staticmethod
-    def get_model_description(robot: Union[Robot, str]) -> pathlib.Path:
+    def get_model_description(robot: Robot | str) -> pathlib.Path:
         """
         Get the URDF file of different robots.
 


### PR DESCRIPTION
This pull request includes several code improvements and bug fixes. Here is a summary of the changes:

- Use structural pattern matching (NOTE: This requires Python>=3.10, so I can eventually drop this)
- Use `utf-8` encoding when reading from files (Avoids file read error in Windows)
- Cache tree transforms
- Cache gazebo executable path
- General exceptions improvements
- General typing improvements

### Benchmarks:

```python
%timeit _ = rod.Sdf.load(sdf=urdf_path, is_urdf=True)
```

```diff
< 683 ms ± 24.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 434 ms ± 11.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```python
%timeit sdf.model.switch_frame_convention(frame_convention=rod.FrameConvention.Urdf)
```

```diff
< 511 ms ± 8.95 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 44 ms ± 178 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

```python
%timeit _ = UrdfExporter.sdf_to_urdf_string(
    sdf=sdf, pretty=True, gazebo_preserve_fixed_joints=True
)
```

```diff
< 549 ms ± 5.71 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
> 73.1 ms ± 432 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

C.C. @diegoferigo 