### PR TITLE
Add support for meshes to primitive builders

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -122,7 +122,8 @@ jobs:
             pptree \
             idyntree \
             pytest \
-            robot_descriptions
+            robot_descriptions \
+            trimesh
             # pytest-icdiff \  # creates problems on macOS
           mamba install -y gz-sim7 idyntree
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ install_requires =
     packaging
     resolve-robotics-uri-py
     scipy
+    trimesh
     xmltodict
 
 [options.extras_require]

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -3,7 +3,7 @@ import pathlib
 from typing import Union
 
 import trimesh
-from numpy.typing import ArrayLike
+from numpy.typing import NDArray
 
 import rod
 from rod.builder.primitive_builder import PrimitiveBuilder
@@ -64,7 +64,7 @@ class CylinderBuilder(PrimitiveBuilder):
 @dataclasses.dataclass
 class MeshBuilder(PrimitiveBuilder):
     mesh_path: Union[str, pathlib.Path]
-    scale: ArrayLike
+    scale: NDArray
 
     def __post_init__(self) -> None:
         self.mesh: trimesh.base.Trimesh = trimesh.load(
@@ -78,7 +78,10 @@ class MeshBuilder(PrimitiveBuilder):
         inertia = self.mesh.moment_inertia
         return rod.Inertia(
             ixx=inertia[0, 0],
+            ixy=inertia[0, 1],
+            ixz=inertia[0, 2],
             iyy=inertia[1, 1],
+            iyz=inertia[1, 2],
             izz=inertia[2, 2],
         )
 

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -73,13 +73,26 @@ class MeshBuilder(PrimitiveBuilder):
 
         Raises:
             AssertionError: If the scale is not a 3D vector.
+            TypeError: If the mesh_path is not a str or pathlib.Path.
         """
+
+        if isinstance(self.mesh_path, str):
+            extension = pathlib.PurePath(self.mesh_path).suffix
+        elif isinstance(self.mesh_path, pathlib.Path):
+            extension = self.mesh_path.suffix
+        else:
+            raise TypeError(
+                f"Expected str or pathlib.Path for mesh_path, got {type(self.mesh_path)}"
+            )
 
         self.mesh: trimesh.base.Trimesh = trimesh.load(
             str(self.mesh_path),
-            file_type="stl",
             force="mesh",
+            file_type=extension.lstrip("."),
         )
+
+        if not isinstance(self.scale, NDArray):
+            raise TypeError(f"Expected numpy.ndarray for scale, got {type(self.scale)}")
         assert self.scale.shape == (
             3,
         ), f"Scale must be a 3D vector, got {self.scale.shape}"

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -77,9 +77,9 @@ class MeshBuilder(PrimitiveBuilder):
         """
 
         if isinstance(self.mesh_path, str):
-            extension = self.mesh_path.split(".")[-1]
+            extension = pathlib.Path(self.mesh_path).suffix
         elif isinstance(self.mesh_path, pathlib.Path):
-            extension = str(self.mesh_path).split(".")[-1]
+            extension = self.mesh_path.suffix
         else:
             raise TypeError(
                 f"Expected str or pathlib.Path for mesh_path, got {type(self.mesh_path)}"

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -67,12 +67,14 @@ class MeshBuilder(PrimitiveBuilder):
     scale: NDArray
 
     def __post_init__(self) -> None:
-        self.mesh: trimesh.base.Trimesh = trimesh.load(
-            str(self.mesh_path), force="mesh"
-        )
-        assert self.scale.shape == (
-            3,
-        ), f"Scale must be a 3D vector, got {self.scale.shape}"
+            self.mesh: trimesh.base.Trimesh = trimesh.load(
+                str(self.mesh_path),
+                file_type="stl",
+                force="mesh",
+            )
+            assert self.scale.shape == (
+                3,
+            ), f"Scale must be a 3D vector, got {self.scale.shape}"
 
     def _inertia(self) -> rod.Inertia:
         inertia = self.mesh.moment_inertia

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -67,14 +67,22 @@ class MeshBuilder(PrimitiveBuilder):
     scale: NDArray
 
     def __post_init__(self) -> None:
-            self.mesh: trimesh.base.Trimesh = trimesh.load(
-                str(self.mesh_path),
-                file_type="stl",
-                force="mesh",
-            )
-            assert self.scale.shape == (
-                3,
-            ), f"Scale must be a 3D vector, got {self.scale.shape}"
+        """
+        Post-initialization method for the class.
+        Loads the mesh from the specified file path and performs necessary checks.
+
+        Raises:
+            AssertionError: If the scale is not a 3D vector.
+        """
+
+        self.mesh: trimesh.base.Trimesh = trimesh.load(
+            str(self.mesh_path),
+            file_type="stl",
+            force="mesh",
+        )
+        assert self.scale.shape == (
+            3,
+        ), f"Scale must be a 3D vector, got {self.scale.shape}"
 
     def _inertia(self) -> rod.Inertia:
         inertia = self.mesh.moment_inertia

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -77,9 +77,9 @@ class MeshBuilder(PrimitiveBuilder):
         """
 
         if isinstance(self.mesh_path, str):
-            extension = pathlib.PurePath(self.mesh_path).suffix
+            extension = self.mesh_path.split(".")[-1]
         elif isinstance(self.mesh_path, pathlib.Path):
-            extension = self.mesh_path.suffix
+            extension = str(self.mesh_path).split(".")[-1]
         else:
             raise TypeError(
                 f"Expected str or pathlib.Path for mesh_path, got {type(self.mesh_path)}"
@@ -88,11 +88,9 @@ class MeshBuilder(PrimitiveBuilder):
         self.mesh: trimesh.base.Trimesh = trimesh.load(
             str(self.mesh_path),
             force="mesh",
-            file_type=extension.lstrip("."),
+            file_type=extension,
         )
 
-        if not isinstance(self.scale, NDArray):
-            raise TypeError(f"Expected numpy.ndarray for scale, got {type(self.scale)}")
         assert self.scale.shape == (
             3,
         ), f"Scale must be a 3D vector, got {self.scale.shape}"

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import tempfile
 
 import numpy as np
 import trimesh
@@ -9,21 +10,20 @@ from rod.builder.primitives import MeshBuilder
 
 def test_builder_creation():
     mesh = trimesh.creation.box([1, 1, 1])
-    # Temporary write to file because rod Mesh works with uri
-    filename = pathlib.Path(__file__).parent / "test_mesh.stl"
-    mesh.export(filename)
-    builder = MeshBuilder(
-        name="test_mesh", mesh_path=filename, mass=1.0, scale=np.array([1.0, 1.0, 1.0])
-    )
-    # Assert on meshes (builder mesh vs trimesh)
-    try:
-        assert builder.mesh.vertices.shape == mesh.vertices.shape
-        assert builder.mesh.faces.shape == mesh.faces.shape
-        assert builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
-        assert builder.mesh.volume == mesh.volume
-    finally:
-        os.remove(filename)
+    print(mesh.vertices.shape)
 
+    # Temporary write to file because rod Mesh works with uri
+    with tempfile.NamedTemporaryFile() as fp:
+        #fp.write(trimesh.exchange.stl.export_stl(mesh))
+        mesh.export(fp.name, file_type="stl")
+
+        builder = MeshBuilder(
+            name="test_mesh", mesh_path=fp.name, mass=1.0, scale=np.array([1.0, 1.0, 1.0])
+        )
+        assert builder.mesh.vertices.shape == mesh.vertices.shape, f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
+        assert builder.mesh.faces.shape == mesh.faces.shape, f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
+        assert builder.mesh.moment_inertia.all() == mesh.moment_inertia.all(), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
+        assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
 
 def test_builder_creation_custom_mesh():
     # Create a custom mesh

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -1,8 +1,10 @@
-from rod.builder.primitives import MeshBuilder
-import trimesh
 import os
-import numpy as np
 import pathlib
+
+import numpy as np
+import trimesh
+
+from rod.builder.primitives import MeshBuilder
 
 
 def test_builder_creation():

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -31,9 +31,7 @@ def test_builder_creation():
     assert (
         builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
     ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
-    assert (
-        builder.mesh.volume == mesh.volume
-    ), f"{builder.mesh.volume} != {mesh.volume}"
+    assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
 
 
 def test_builder_creation_custom_mesh():
@@ -62,6 +60,4 @@ def test_builder_creation_custom_mesh():
     assert (
         builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
     ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
-    assert (
-        builder.mesh.volume == mesh.volume
-    ), f"{builder.mesh.volume} != {mesh.volume}"
+    assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -14,16 +14,28 @@ def test_builder_creation():
 
     # Temporary write to file because rod Mesh works with uri
     with tempfile.NamedTemporaryFile() as fp:
-        #fp.write(trimesh.exchange.stl.export_stl(mesh))
+        # fp.write(trimesh.exchange.stl.export_stl(mesh))
         mesh.export(fp.name, file_type="stl")
 
         builder = MeshBuilder(
-            name="test_mesh", mesh_path=fp.name, mass=1.0, scale=np.array([1.0, 1.0, 1.0])
+            name="test_mesh",
+            mesh_path=fp.name,
+            mass=1.0,
+            scale=np.array([1.0, 1.0, 1.0]),
         )
-        assert builder.mesh.vertices.shape == mesh.vertices.shape, f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
-        assert builder.mesh.faces.shape == mesh.faces.shape, f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
-        assert builder.mesh.moment_inertia.all() == mesh.moment_inertia.all(), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
-        assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
+        assert (
+            builder.mesh.vertices.shape == mesh.vertices.shape
+        ), f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
+        assert (
+            builder.mesh.faces.shape == mesh.faces.shape
+        ), f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
+        assert (
+            builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
+        ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
+        assert (
+            builder.mesh.volume == mesh.volume
+        ), f"{builder.mesh.volume} != {mesh.volume}"
+
 
 def test_builder_creation_custom_mesh():
     # Create a custom mesh

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -13,7 +13,6 @@ def test_builder_creation():
 
     # Temporary write to file because rod Mesh works with uri
     with tempfile.NamedTemporaryFile() as fp:
-        # fp.write(trimesh.exchange.stl.export_stl(mesh))
         mesh.export(fp.name, file_type="stl")
 
         builder = MeshBuilder(
@@ -42,7 +41,6 @@ def test_builder_creation_custom_mesh():
 
     # Temporary write to file because rod Mesh works with uri
     with tempfile.NamedTemporaryFile() as fp:
-        # fp.write(trimesh.exchange.stl.export_stl(mesh))
         mesh.export(fp.name, file_type="stl")
 
         builder = MeshBuilder(

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -1,0 +1,50 @@
+from rod.builder.primitives import MeshBuilder
+import trimesh
+import os
+import numpy as np
+import pathlib
+
+
+def test_builder_creation():
+    mesh = trimesh.creation.box([1, 1, 1])
+    # Temporary write to file because rod Mesh works with uri
+    filename = pathlib.Path(__file__).parent / "test_mesh.stl"
+    mesh.export(filename)
+    builder = MeshBuilder(
+        name="test_mesh", mesh_path=filename, mass=1.0, scale=np.array([1.0, 1.0, 1.0])
+    )
+    # Assert on meshes (builder mesh vs trimesh)
+    try:
+        assert builder.mesh.vertices.shape == mesh.vertices.shape
+        assert builder.mesh.faces.shape == mesh.faces.shape
+        assert builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
+        assert builder.mesh.volume == mesh.volume
+    finally:
+        os.remove(filename)
+
+
+def test_builder_creation_custom_mesh():
+    # Create a custom mesh
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    custom_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+
+    # Temporary write to file because rod Mesh works with uri
+    filename = pathlib.Path(__file__).parent / "test_custom_mesh.stl"
+    custom_mesh.export(filename)
+
+    builder = MeshBuilder(
+        name="test_custom_mesh",
+        mesh_path=filename,
+        mass=1.0,
+        scale=np.array([1.0, 1.0, 1.0]),
+    )
+
+    # Assert on meshes (builder mesh vs custom_mesh)
+    try:
+        assert builder.mesh.vertices.shape == custom_mesh.vertices.shape
+        assert builder.mesh.faces.shape == custom_mesh.faces.shape
+        assert builder.mesh.moment_inertia.all() == custom_mesh.moment_inertia.all()
+        assert builder.mesh.volume == custom_mesh.volume
+    finally:
+        os.remove(filename)

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -10,7 +10,6 @@ from rod.builder.primitives import MeshBuilder
 
 def test_builder_creation():
     mesh = trimesh.creation.box([1, 1, 1])
-    print(mesh.vertices.shape)
 
     # Temporary write to file because rod Mesh works with uri
     with tempfile.NamedTemporaryFile() as fp:
@@ -23,42 +22,46 @@ def test_builder_creation():
             mass=1.0,
             scale=np.array([1.0, 1.0, 1.0]),
         )
-        assert (
-            builder.mesh.vertices.shape == mesh.vertices.shape
-        ), f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
-        assert (
-            builder.mesh.faces.shape == mesh.faces.shape
-        ), f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
-        assert (
-            builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
-        ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
-        assert (
-            builder.mesh.volume == mesh.volume
-        ), f"{builder.mesh.volume} != {mesh.volume}"
+    assert (
+        builder.mesh.vertices.shape == mesh.vertices.shape
+    ), f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
+    assert (
+        builder.mesh.faces.shape == mesh.faces.shape
+    ), f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
+    assert (
+        builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
+    ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
+    assert (
+        builder.mesh.volume == mesh.volume
+    ), f"{builder.mesh.volume} != {mesh.volume}"
 
 
 def test_builder_creation_custom_mesh():
     # Create a custom mesh
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[0, 1, 2], [0, 2, 3]])
-    custom_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+    mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
 
     # Temporary write to file because rod Mesh works with uri
-    filename = pathlib.Path(__file__).parent / "test_custom_mesh.stl"
-    custom_mesh.export(filename)
+    with tempfile.NamedTemporaryFile() as fp:
+        # fp.write(trimesh.exchange.stl.export_stl(mesh))
+        mesh.export(fp.name, file_type="stl")
 
-    builder = MeshBuilder(
-        name="test_custom_mesh",
-        mesh_path=filename,
-        mass=1.0,
-        scale=np.array([1.0, 1.0, 1.0]),
-    )
-
-    # Assert on meshes (builder mesh vs custom_mesh)
-    try:
-        assert builder.mesh.vertices.shape == custom_mesh.vertices.shape
-        assert builder.mesh.faces.shape == custom_mesh.faces.shape
-        assert builder.mesh.moment_inertia.all() == custom_mesh.moment_inertia.all()
-        assert builder.mesh.volume == custom_mesh.volume
-    finally:
-        os.remove(filename)
+        builder = MeshBuilder(
+            name="test_mesh",
+            mesh_path=fp.name,
+            mass=1.0,
+            scale=np.array([1.0, 1.0, 1.0]),
+        )
+    assert (
+        builder.mesh.vertices.shape == mesh.vertices.shape
+    ), f"{builder.mesh.vertices.shape} != {mesh.vertices.shape}"
+    assert (
+        builder.mesh.faces.shape == mesh.faces.shape
+    ), f"{builder.mesh.faces.shape} != {mesh.faces.shape}"
+    assert (
+        builder.mesh.moment_inertia.all() == mesh.moment_inertia.all()
+    ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
+    assert (
+        builder.mesh.volume == mesh.volume
+    ), f"{builder.mesh.volume} != {mesh.volume}"

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -12,7 +12,7 @@ def test_builder_creation():
     mesh = trimesh.creation.box([1, 1, 1])
 
     # Temporary write to file because rod Mesh works with uri
-    with tempfile.NamedTemporaryFile() as fp:
+    with tempfile.NamedTemporaryFile(suffix=".stl") as fp:
         mesh.export(fp.name, file_type="stl")
 
         builder = MeshBuilder(
@@ -40,7 +40,7 @@ def test_builder_creation_custom_mesh():
     mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
 
     # Temporary write to file because rod Mesh works with uri
-    with tempfile.NamedTemporaryFile() as fp:
+    with tempfile.NamedTemporaryFile(suffix=".stl") as fp:
         mesh.export(fp.name, file_type="stl")
 
         builder = MeshBuilder(


### PR DESCRIPTION
This pull requests adds the possibility to build meshes by using [trimesh](https://github.com/mikedh/trimesh).
It implements a `MeshBuilder` class which implements the calculation for the mesh's moment of inertia and its geometry.

Summary of changes:
- Implement MeshBuilder object and override its `inertia` and `geometry` methods with a calculation using `trimesh` methods.
- Implement tests on mesh-building.