### PR TITLE
Enhance processing and URDF export of `//frame` elements

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,7 +104,11 @@ jobs:
         if: matrix.type == 'apt'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gazebo
+          sudo apt-get install lsb-release wget gnupg
+          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libsdformat13 gz-tools2
 
       - name: Install conda dependencies
         if: matrix.type == 'conda'

--- a/src/rod/__init__.py
+++ b/src/rod/__init__.py
@@ -23,8 +23,16 @@ from .sdf.visual import Visual
 from .sdf.world import World
 from .utils.frame_convention import FrameConvention
 
+# ===============================
+# Configure the logging verbosity
+# ===============================
+
 
 def _is_editable():
+    """
+    Check if the rod package is installed in editable mode.
+    """
+
     import importlib.util
     import pathlib
     import site
@@ -43,7 +51,7 @@ def _is_editable():
     return rod_package_dir not in site.getsitepackages()
 
 
-# Initialize the logging verbosity
+# Initialize the logging verbosity depending on the installation mode.
 logging.configure(
     level=logging.LoggingLevel.DEBUG if _is_editable() else logging.LoggingLevel.WARNING
 )

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -14,18 +14,15 @@ class TreeTransforms:
     kinematic_tree: KinematicTree = dataclasses.dataclass(init=False)
 
     @staticmethod
-    def build(
-        model: "rod.Model",
-        is_top_level: bool = True,
-        prevent_switching_frame_convention: bool = False,
-    ) -> "TreeTransforms":
+    def build(model: "rod.Model", is_top_level: bool = True) -> "TreeTransforms":
+
+        # Operate on a deep copy of the model to avoid side effects.
         model = copy.deepcopy(model)
 
+        # Make sure that all elements have a pose attribute with explicit 'relative_to'.
         model.resolve_frames(is_top_level=is_top_level, explicit_frames=True)
 
-        if not prevent_switching_frame_convention:
-            model.switch_frame_convention(frame_convention=rod.FrameConvention.Urdf)
-
+        # Build the kinematic tree and return the TreeTransforms object.
         return TreeTransforms(
             kinematic_tree=KinematicTree.build(model=model, is_top_level=is_top_level)
         )

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -51,26 +51,35 @@ class TreeTransforms:
 
             return W_H_E
 
-        if (
-            name in self.kinematic_tree.link_names()
-            or name in self.kinematic_tree.frame_names()
-        ):
-            element = (
-                self.kinematic_tree.links_dict[name]
-                if name in self.kinematic_tree.link_names()
-                else self.kinematic_tree.frames_dict[name]
-            )
-            assert element.name() == name
+        if name in self.kinematic_tree.link_names():
 
-            # Get the pose of the frame in which the node's pose is expressed
+            element = self.kinematic_tree.links_dict[name]
+
+            assert element.name() == name
             assert element._source.pose.relative_to not in {"", None}
-            x_H_N = element._source.pose.transform()
+
+            # Get the pose of the frame in which the link's pose is expressed.
+            x_H_L = element._source.pose.transform()
             W_H_x = self.transform(name=element._source.pose.relative_to)
 
-            # Compute and cache the world-to-node transform
-            W_H_N = W_H_x @ x_H_N
+            # Compute the world transform of the link.
+            W_H_L = W_H_x @ x_H_L
+            return W_H_L
 
-            return W_H_N
+        if name in self.kinematic_tree.frame_names():
+
+            element = self.kinematic_tree.frames_dict[name]
+
+            assert element.name() == name
+            assert element._source.pose.relative_to not in {"", None}
+
+            # Get the pose of the frame in which the frame's pose is expressed.
+            x_H_F = element._source.pose.transform()
+            W_H_x = self.transform(name=element._source.pose.relative_to)
+
+            # Compute the world transform of the frame.
+            W_H_F = W_H_x @ x_H_F
+            return W_H_F
 
         raise ValueError(name)
 

--- a/src/rod/kinematics/tree_transforms.py
+++ b/src/rod/kinematics/tree_transforms.py
@@ -75,6 +75,21 @@ class TreeTransforms:
         raise ValueError(name)
 
     def relative_transform(self, relative_to: str, name: str) -> npt.NDArray:
-        return np.linalg.inv(self.transform(name=relative_to)) @ self.transform(
-            name=name
+
+        world_H_name = self.transform(name=name)
+        world_H_relative_to = self.transform(name=relative_to)
+
+        return TreeTransforms.inverse(world_H_relative_to) @ world_H_name
+
+    @staticmethod
+    def inverse(transform: npt.NDArray) -> npt.NDArray:
+
+        R = transform[0:3, 0:3]
+        p = np.vstack(transform[0:3, 3])
+
+        return np.block(
+            [
+                [R.T, -R.T @ p],
+                [0, 0, 0, 1],
+            ]
         )

--- a/src/rod/sdf/model.py
+++ b/src/rod/sdf/model.py
@@ -158,6 +158,7 @@ class Model(Element):
         frame_convention: "rod.FrameConvention",
         is_top_level: bool = True,
         explicit_frames: bool = True,
+        attach_frames_to_links: bool = True,
     ) -> None:
         from rod.utils.frame_convention import switch_frame_convention
 
@@ -165,6 +166,7 @@ class Model(Element):
             model=self,
             frame_convention=frame_convention,
             is_top_level=is_top_level,
+            attach_frames_to_links=attach_frames_to_links,
         )
 
         self.resolve_frames(is_top_level=is_top_level, explicit_frames=explicit_frames)

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -233,6 +233,12 @@ class UrdfExporter(abc.ABC):
 
         assert isinstance(gazebo_preserve_fixed_joints, list)
 
+        # Check that all fixed joints to preserve are actually present in the model.
+        for fixed_joint_name in gazebo_preserve_fixed_joints:
+            all_model_joint_names = {j.name for j in model.joints()}
+            if fixed_joint_name not in all_model_joint_names:
+                raise RuntimeError(f"Joint '{fixed_joint_name}' not found in the model")
+
         # ===================
         # Convert SDF to URDF
         # ===================

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -166,7 +166,7 @@ class UrdfExporter(abc.ABC):
                         "@ixy": 0.0,
                         "@ixz": 0.0,
                         "@iyy": 0.0,
-                        "@iyz": 0,
+                        "@iyz": 0.0,
                         "@izz": 0.0,
                     },
                 },

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -162,40 +162,23 @@ class UrdfExporter(abc.ABC):
                 relative_to=parent_link_name,
             )
 
-            # Smallest value not ignored by sdformat
-            epsilon = 1e-6 + 1e-9
-
             # New dummy link with same name of the frame
             new_link = {
                 "@name": frame.name,
-                # If the link has no inertial properties, parsing again the exported
-                # URDF model with SDF would ignore it.
-                # We need to add a tiny fake mass greater than 1e-6.
-                # https://github.com/gazebosim/sdformat/issues/199#issuecomment-622127508
                 "inertial": {
                     "origin": {
                         "@xyz": "0 0 0",
                         "@rpy": "0 0 0",
                     },
-                    "mass": {"@value": str(epsilon)},
+                    "mass": {"@value": 0.0},
                     "inertia": {
-                        "@ixx": str(epsilon),
-                        "@ixy": 0,
-                        "@ixz": 0,
-                        "@iyy": str(epsilon),
+                        "@ixx": 0.0,
+                        "@ixy": 0.0,
+                        "@ixz": 0.0,
+                        "@iyy": 0.0,
                         "@iyz": 0,
-                        "@izz": str(epsilon),
+                        "@izz": 0.0,
                     },
-                },
-                "visual": {
-                    "@name": f"{frame.name}_visual",
-                    "origin": {
-                        "@xyz": "0 0 0",
-                        "@rpy": "0 0 0",
-                    },
-                    "geometry": UrdfExporter._rod_geometry_to_xmltodict(
-                        geometry=rod.Geometry(sphere=rod.Sphere(radius=0.0))
-                    ),
                 },
             }
 
@@ -412,14 +395,6 @@ class UrdfExporter(abc.ABC):
                 # https://classic.gazebosim.org/tutorials?tut=ros_urdf
                 # https://github.com/gazebosim/sdformat/issues/199#issuecomment-622127508
                 "gazebo": [
-                    {
-                        "@reference": extra_joint["@name"],
-                        "preserveFixedJoint": "true",
-                        "disableFixedJointLumping": "true",
-                    }
-                    for extra_joint in extra_joints_from_frames
-                ]
-                + [
                     {
                         "@reference": fixed_joint,
                         "preserveFixedJoint": "true",

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -76,6 +76,7 @@ class UrdfExporter(abc.ABC):
 
         # Get the model
         model = sdf if isinstance(sdf, rod.Model) else sdf.models()[0]
+        logging.debug(f"Converting model '{model.name}' to URDF")
 
         # Remove all poses that could be assumed being implicit
         model.resolve_frames(is_top_level=True, explicit_frames=False)
@@ -102,6 +103,7 @@ class UrdfExporter(abc.ABC):
             model.pose = None
 
         # Get the canonical link of the model
+        logging.debug(f"Detected '{model.get_canonical_link()}' as root link")
         canonical_link: rod.Link = {l.name: l for l in model.links()}[
             model.get_canonical_link()
         ]
@@ -220,6 +222,7 @@ class UrdfExporter(abc.ABC):
 
         # Check that all fixed joints to preserve are actually present in the model.
         for fixed_joint_name in gazebo_preserve_fixed_joints:
+            logging.debug(f"Preserving fixed joint '{fixed_joint_name}'")
             all_model_joint_names = {j.name for j in model.joints()}
             if fixed_joint_name not in all_model_joint_names:
                 raise RuntimeError(f"Joint '{fixed_joint_name}' not found in the model")

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -133,11 +133,7 @@ class UrdfExporter(abc.ABC):
         # Tree transforms helper used to process SDF frame poses, if any.
         # No need to switch frame convention to Urdf since it was already done above.
         tree_transforms = (
-            TreeTransforms.build(
-                model=model,
-                is_top_level=True,
-                prevent_switching_frame_convention=True,
-            )
+            TreeTransforms.build(model=model, is_top_level=True)
             if len(model.frames()) is not None
             else None
         )

--- a/src/rod/urdf/exporter.py
+++ b/src/rod/urdf/exporter.py
@@ -121,9 +121,13 @@ class UrdfExporter(abc.ABC):
             canonical_link.pose = None
 
         # Convert all poses to use the Urdf frames convention.
-        # This process drastically simplifies extracting compatible kinematic trasforms.
+        # This process drastically simplifies extracting compatible kinematic transforms.
+        # Furthermore, it post-processes frames such that they get directly attached to
+        # a real link (instead of being attached to other frames).
         model.switch_frame_convention(
-            frame_convention=rod.FrameConvention.Urdf, explicit_frames=True
+            frame_convention=rod.FrameConvention.Urdf,
+            explicit_frames=True,
+            attach_frames_to_links=True,
         )
 
         # ============================================

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -15,16 +15,63 @@ class FrameConvention(enum.IntEnum):
 
 
 def switch_frame_convention(
-    model: "rod.Model", frame_convention: FrameConvention, is_top_level: bool = True
+    model: "rod.Model",
+    frame_convention: FrameConvention,
+    is_top_level: bool = True,
+    attach_frames_to_links: bool = True,
 ) -> None:
+
     # Resolve all implicit reference frames using Sdf convention
     model.resolve_frames(is_top_level=is_top_level, explicit_frames=True)
+
+    # =============================
+    # Initialize forward kinematics
+    # =============================
+
+    from rod.kinematics.tree_transforms import TreeTransforms
+
+    # Create the object to compute the kinematics of the tree.
+    kin = TreeTransforms.build(model=model, is_top_level=is_top_level)
+
+    # =====================================
+    # Update frames to be attached to links
+    # =====================================
+
+    # Update the //frame/attached_to attribute of all frames so that they are
+    # directly attached to links.
+    if attach_frames_to_links:
+        for frame in model.frames():
+            # Find the link to which the frame is attached to following recursively
+            # the //frame/attached_to attribute.
+            parent_link = find_parent_link_of_frame(frame=frame, model=model)
+
+            # Compute the transform between the model and the frame.
+            model_H_frame = (
+                kin.relative_transform(
+                    relative_to="__model__", name=frame.pose.relative_to
+                )
+                @ frame.pose.transform()
+            )
+
+            # Compute the transform between the parent link and the model.
+            parent_link_H_model = kin.relative_transform(
+                relative_to=parent_link, name="__model__"
+            )
+
+            # Update the frame such that it is attached_to a link, populating the
+            # pose with the correct transform between the parent link and the frame.
+            frame.attached_to = parent_link
+            frame.pose = rod.Pose.from_transform(
+                relative_to=parent_link,
+                transform=parent_link_H_model @ model_H_frame,
+            )
 
     # =============================================================
     # Define the default reference frames of the different elements
     # =============================================================
 
     if frame_convention is FrameConvention.World:
+
         reference_frame_model = lambda m: "world"
         reference_frame_links = lambda l: "world"
         reference_frame_frames = lambda f: "world"
@@ -35,6 +82,7 @@ def switch_frame_convention(
         reference_frame_link_canonical = "world"
 
     elif frame_convention is FrameConvention.Model:
+
         reference_frame_model = lambda m: "world"
         reference_frame_links = lambda l: "__model__"
         reference_frame_frames = lambda f: "__model__"
@@ -45,6 +93,7 @@ def switch_frame_convention(
         reference_frame_link_canonical = "__model__"
 
     elif frame_convention is FrameConvention.Sdf:
+
         visual_name_to_parent_link = {
             visual_name: parent_link
             for d in [{v.name: link for v in link.visuals()} for link in model.links()]
@@ -61,7 +110,7 @@ def switch_frame_convention(
 
         reference_frame_model = lambda m: "world"
         reference_frame_links = lambda l: "__model__"
-        reference_frame_frames = lambda f: "__model__"
+        reference_frame_frames = lambda f: f.attached_to
         reference_frame_joints = lambda j: joint.child
         reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
         reference_frame_inertials = lambda i, parent_link: parent_link.name
@@ -71,6 +120,7 @@ def switch_frame_convention(
         reference_frame_link_canonical = "__model__"
 
     elif frame_convention is FrameConvention.Urdf:
+
         visual_name_to_parent_link = {
             visual_name: parent_link
             for d in [{v.name: link for v in link.visuals()} for link in model.links()]
@@ -98,7 +148,7 @@ def switch_frame_convention(
 
         reference_frame_model = lambda m: "world"
         reference_frame_links = lambda l: link_name_to_parent_joint_names[l.name][0]
-        reference_frame_frames = lambda f: "__model__"
+        reference_frame_frames = lambda f: f.attached_to
         reference_frame_joints = lambda j: j.parent
         reference_frame_visuals = lambda v: visual_name_to_parent_link[v.name].name
         reference_frame_inertials = lambda i, parent_link: parent_link.name
@@ -113,17 +163,13 @@ def switch_frame_convention(
             reference_frame_link_canonical = reference_frame_links(l=canonical_link)
         else:
             reference_frame_link_canonical = "__model__"
+
     else:
         raise ValueError(frame_convention)
 
     # =========================================
     # Process the reference frames of the model
     # =========================================
-
-    from rod.kinematics.tree_transforms import TreeTransforms
-
-    # Create the tree from the model.
-    kin = TreeTransforms.build(model=model, is_top_level=is_top_level)
 
     if is_top_level:
         assert model.pose.relative_to in {"", None}
@@ -165,8 +211,7 @@ def switch_frame_convention(
 
     # Adjust the reference frames of all frames
     for frame in model.frames():
-        x_H_frame = frame.pose.transform() if frame.pose is not None else np.eye(4)
-
+        x_H_frame = frame.pose.transform()
         target_H_x = kin.relative_transform(
             relative_to=reference_frame_frames(f=frame),
             name=frame.pose.relative_to,
@@ -232,3 +277,44 @@ def switch_frame_convention(
                 relative_to=reference_frame_collisions(c=collision),
                 transform=target_H_x @ x_H_collision,
             )
+
+
+def find_parent_link_of_frame(frame: rod.Frame, model: rod.Model) -> str:
+
+    links_dict = {l.name: l for l in model.links()}
+    frames_dict = {f.name: f for f in model.frames()}
+    joints_dict = {j.name: j for j in model.joints()}
+    sub_models_dict = {m.name: m for m in model.models()}
+
+    assert isinstance(frame, rod.Frame)
+
+    if frame.attached_to in links_dict:
+        parent = links_dict[frame.attached_to]
+
+    elif frame.attached_to in frames_dict:
+        parent = frames_dict[frame.attached_to]
+
+    elif frame.attached in {model.name, "__model__"}:
+        return model.get_canonical_link()
+
+    elif frame.attached_to in joints_dict:
+        raise ValueError("Frames cannot be attached to joints")
+
+    elif frame.attached_to in sub_models_dict:
+        raise RuntimeError("Model composition not yet supported")
+
+    else:
+        raise RuntimeError(f"Failed to find element with name '{frame.attached_to}'")
+
+    # At this point, the parent is either a link or another frame.
+    assert isinstance(parent, (rod.Link, rod.Frame))
+
+    # If the parent is a link, can stop searching.
+    if isinstance(parent, rod.Link):
+        return parent.name
+
+    # If the parent is another frame, keep looking for the parent link.
+    if isinstance(parent, rod.Frame):
+        return find_parent_link_of_frame(frame=parent, model=model)
+
+    raise RuntimeError("This recursive function should never arrive here.")

--- a/src/rod/utils/frame_convention.py
+++ b/src/rod/utils/frame_convention.py
@@ -122,11 +122,8 @@ def switch_frame_convention(
 
     from rod.kinematics.tree_transforms import TreeTransforms
 
-    # Create the tree from the model, using the original frame convention
-    # (otherwise it would call this helper obtaining an infinite loop)
-    kin = TreeTransforms.build(
-        model=model, is_top_level=is_top_level, prevent_switching_frame_convention=True
-    )
+    # Create the tree from the model.
+    kin = TreeTransforms.build(model=model, is_top_level=is_top_level)
 
     if is_top_level:
         assert model.pose.relative_to in {"", None}

--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -78,9 +78,19 @@ class GazeboHelper:
         # Get the Gazebo Sim executable (raises exception if not found)
         gazebo_executable = GazeboHelper.get_gazebo_executable()
 
-        with tempfile.NamedTemporaryFile(mode="w+") as fp:
-            fp.write(model_description_string)
-            fp.seek(0)
+        # Operate on a file stored in a temporary directory.
+        # This is necessary on windows because the file has to be closed before
+        # it can be processed by the sdformat executable.
+        # As soon as 3.12 will be the minimum supported version, we can use just
+        # NamedTemporaryFile with the new delete_on_close=False parameter.
+        with tempfile.TemporaryDirectory() as tmp:
+
+            with tempfile.NamedTemporaryFile(
+                mode="w+", suffix=".xml", dir=tmp, delete=False
+            ) as fp:
+
+                fp.write(model_description_string)
+                fp.close()
 
             cp = subprocess.run(
                 [str(gazebo_executable), "sdf", "-p", fp.name],

--- a/src/rod/utils/resolve_frames.py
+++ b/src/rod/utils/resolve_frames.py
@@ -69,7 +69,13 @@ def resolve_model_frames(
         update_element(element=model, default_relative_to="world")
 
     for frame in model.frames():
-        update_element(element=frame, default_relative_to=["__model__", model.name])
+        update_element(
+            element=frame,
+            default_relative_to=(
+                [frame.attached_to] if frame.attached_to is not None else []
+            )
+            + [model.get_canonical_link()],
+        )
 
     # Update the links and its children elements
     for link in model.links():

--- a/tests/test_urdf_exporter.py
+++ b/tests/test_urdf_exporter.py
@@ -1,0 +1,125 @@
+import idyntree.bindings as idt
+import numpy as np
+import numpy.typing as npt
+import pytest
+from utils_models import ModelFactory, Robot
+
+import rod
+import rod.urdf.exporter
+
+
+@pytest.mark.parametrize(
+    "robot",
+    [
+        Robot.iCub,
+        Robot.DoublePendulum,
+        Robot.Cassie,
+        Robot.Ur10,
+        Robot.AtlasV4,
+        Robot.Ergocub,
+    ],
+)
+def test_urdf_exporter(robot: Robot) -> None:
+    """Test exporting URDF files."""
+
+    # Get the path to the URDF.
+    original_urdf_path = ModelFactory.get_model_description(robot=robot)
+
+    # Load the URDF (it gets converted to SDF internally).
+    sdf = rod.Sdf.load(sdf=original_urdf_path, is_urdf=True)
+
+    # Export the URDF from the in-memory SDF-based description.
+    exported_urdf_string = rod.urdf.exporter.UrdfExporter().to_urdf_string(sdf=sdf)
+
+    # Create two model loaders.
+    mdl_loader_original = idt.ModelLoader()
+    mdl_loader_exported = idt.ModelLoader()
+
+    # Get the joint serialization from ROD.
+    joint_names = [j.name for j in sdf.model.joints() if j.type != "fixed"]
+
+    # Load the original URDF.
+    assert mdl_loader_original.loadReducedModelFromString(
+        original_urdf_path.read_text(), joint_names
+    )
+
+    # Load the exported URDF.
+    assert mdl_loader_exported.loadReducedModelFromString(
+        exported_urdf_string, joint_names
+    )
+
+    # Create two KinDynComputations objects, one for the original URDF and
+    # one for the exported URDF.
+    kin_dyn_original = idt.KinDynComputations()
+    kin_dyn_exported = idt.KinDynComputations()
+
+    # Load the two robot models in the KinDynComputations objects.
+    assert kin_dyn_original.loadRobotModel(mdl_loader_original.model())
+    assert kin_dyn_exported.loadRobotModel(mdl_loader_exported.model())
+
+    # Get all the links and frames from the original URDF.
+    all_original_frames = [
+        kin_dyn_original.getFrameName(i)
+        for i in range(
+            kin_dyn_original.getNrOfLinks(), kin_dyn_original.getNrOfFrames()
+        )
+    ]
+
+    all_exported_frames = [
+        kin_dyn_exported.getFrameName(i)
+        for i in range(
+            kin_dyn_exported.getNrOfLinks(), kin_dyn_exported.getNrOfFrames()
+        )
+    ]
+
+    # =================================
+    # Test that kinematics is preserved
+    # =================================
+
+    def get_frame_transform(
+        kin_dyn: idt.KinDynComputations, frame_name: str
+    ) -> npt.NDArray:
+
+        frame_idx = kin_dyn.getFrameIndex(frame_name)
+        assert frame_idx >= 0, frame_name
+
+        if frame_name == kin_dyn.getFloatingBase():
+            H_idt = kin_dyn.getWorldBaseTransform()
+        else:
+            H_idt = kin_dyn.getWorldTransform(frame_name)
+
+        H = np.eye(4)
+        H[0:3, 3] = H_idt.getPosition().toNumPy()
+        H[0:3, 0:3] = H_idt.getRotation().toNumPy()
+
+        return H
+
+    for frame in set(all_original_frames).intersection(all_exported_frames):
+
+        W_H_F_original = get_frame_transform(kin_dyn=kin_dyn_original, frame_name=frame)
+        W_H_F_exported = get_frame_transform(kin_dyn=kin_dyn_exported, frame_name=frame)
+
+        assert W_H_F_exported == pytest.approx(W_H_F_original, abs=1e-6), (
+            frame,
+            W_H_F_original,
+            W_H_F_exported,
+            np.abs(W_H_F_original - W_H_F_exported),
+        )
+
+    # ===============================
+    # Test that dynamics is preserved
+    # ===============================
+
+    mass_original = kin_dyn_original.model().getTotalMass()
+    mass_exported = kin_dyn_exported.model().getTotalMass()
+    assert mass_exported == pytest.approx(mass_original, abs=1e-6)
+
+    locked_inertia_original = (
+        kin_dyn_original.getRobotLockedInertia().asMatrix().toNumPy()
+    )
+
+    locked_inertia_exported = (
+        kin_dyn_exported.getRobotLockedInertia().asMatrix().toNumPy()
+    )
+
+    assert locked_inertia_exported == pytest.approx(locked_inertia_original, abs=1e-6)


### PR DESCRIPTION
This PR:

- Fixes the computation of the `//frame/pose` element when not explicitly defined in the model description following the [documented semantics](http://sdformat.org/tutorials?tut=pose_frame_semantics&cat=specification&#frame) (pay attention how the pose is defined when there is no explicit `//frame/pose`, and what's the default when also `//frame/attached_to` is not defined).
- Enhances the process of converting ` //frame` elements to compatible chains in URDF.

---

In the last two year, `sdformat` received different updates on how URDF models are converted to SDF. In particular, few of them altered how kinematic chains involving massless links (or with tiny masses) are processed. Here below some references for those that want to dig deeper:

- https://github.com/gazebosim/sdformat/pull/1238 
- https://github.com/gazebosim/sdformat/pull/1148
- https://github.com/gazebosim/sdformat/issues/199#issuecomment-622127508

TL;DR

- Before, links with mass smaller than 1e-6 were completely ignored, now instead they become frames.
- Before, child link of fixed joints (without additional tags for keeping such joints) were lumped into the parent link of the joint, therefore disappearing in the output model. Now, when a link is lumped, instead of disappear, becomes a SDF frame.

This PR bumps the minimum version of `sdformat` to 12.x such that the processing of such cases is handled in a unique way. Then, in order to prevent the need to install a full Gazebo suite, the minimum `sdformat` version is raised to 13.x. This version allows to have the `gz sdf` command line just by installing a small subset of the Gazebo libraries. 

---

Some further details on the logic introduced by this PR:

- Switching frame convention has now an additional `attach_frames_to_links` option to update the `//frame/attached_to` element to be a link, following recursively the hierarchy. In this way, downstream projects can post-process easily frames attached to other frames knowing their real parent link. 
- The inverse of a transform is now computed without inverting the original transform.