### PR TITLE
Improved meshbuilder's mesh handling

### DIFF
--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -1,10 +1,10 @@
 import dataclasses
+import os
 import pathlib
 
 import trimesh
 from numpy.typing import NDArray
 
-import os
 import rod
 from rod.builder.primitive_builder import PrimitiveBuilder
 
@@ -80,7 +80,9 @@ class MeshBuilder(PrimitiveBuilder):
         if os.stat(self.mesh_path).st_size == 0:
             # File is empty
             self.is_empty = True
-            rod.logging.warning(f"Meshbuilder instantiated with empty mesh file {self.mesh_path}")
+            rod.logging.warning(
+                f"Meshbuilder instantiated with empty mesh file {self.mesh_path}"
+            )
 
         if isinstance(self.mesh_path, str):
             extension = pathlib.Path(self.mesh_path).suffix

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -4,6 +4,7 @@ import pathlib
 import trimesh
 from numpy.typing import NDArray
 
+import os
 import rod
 from rod.builder.primitive_builder import PrimitiveBuilder
 
@@ -75,6 +76,10 @@ class MeshBuilder(PrimitiveBuilder):
             TypeError: If the mesh_path is not a str or pathlib.Path.
         """
 
+        if os.stat(self.mesh_path).st_size == 0:
+            # File is empty
+            rod.logging.warning(f"Meshbuilder instantiated with empty mesh file {self.mesh_path}")
+
         if isinstance(self.mesh_path, str):
             extension = pathlib.Path(self.mesh_path).suffix
         elif isinstance(self.mesh_path, pathlib.Path):
@@ -84,11 +89,11 @@ class MeshBuilder(PrimitiveBuilder):
                 f"Expected str or pathlib.Path for mesh_path, got {type(self.mesh_path)}"
             )
 
-        self.mesh: trimesh.base.Trimesh = trimesh.load(
-            str(self.mesh_path),
-            force="mesh",
-            file_type=extension,
-        )
+        with open(self.mesh_path, "rb") as f:
+            self.mesh: trimesh.base.Trimesh = trimesh.load_mesh(
+                file_obj=f,
+                file_type=extension,
+            )
 
         assert self.scale.shape == (
             3,

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -76,28 +76,13 @@ class MeshBuilder(PrimitiveBuilder):
             AssertionError: If the scale is not a 3D vector.
             TypeError: If the mesh_path is not a str or pathlib.Path.
         """
+        mesh_path = pathlib.Path(self.mesh_path)
+        if not mesh_path.is_file():
+            raise FileNotFoundError(f"Mesh file not found at {self.mesh_path}")
 
-        if os.stat(self.mesh_path).st_size == 0:
-            # File is empty
-            self.is_empty = True
-            rod.logging.warning(
-                f"Meshbuilder instantiated with empty mesh file {self.mesh_path}"
-            )
-
-        if isinstance(self.mesh_path, str):
-            extension = pathlib.Path(self.mesh_path).suffix
-        elif isinstance(self.mesh_path, pathlib.Path):
-            extension = self.mesh_path.suffix
-        else:
-            raise TypeError(
-                f"Expected str or pathlib.Path for mesh_path, got {type(self.mesh_path)}"
-            )
-
-        with open(self.mesh_path, "rb") as f:
-            self.mesh: trimesh.base.Trimesh = trimesh.load_mesh(
-                file_obj=f,
-                file_type=extension,
-            )
+        self.mesh: trimesh.base.Trimesh = trimesh.load_mesh(
+            file_obj=mesh_path,
+        )
 
         assert self.scale.shape == (
             3,

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -1,5 +1,4 @@
 import dataclasses
-import os
 import pathlib
 
 import trimesh
@@ -65,7 +64,6 @@ class CylinderBuilder(PrimitiveBuilder):
 class MeshBuilder(PrimitiveBuilder):
     mesh_path: str | pathlib.Path
     scale: NDArray
-    is_empty: bool = False
 
     def __post_init__(self) -> None:
         """

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -74,7 +74,13 @@ class MeshBuilder(PrimitiveBuilder):
             AssertionError: If the scale is not a 3D vector.
             TypeError: If the mesh_path is not a str or pathlib.Path.
         """
-        mesh_path = pathlib.Path(self.mesh_path)
+
+        mesh_path = (
+            self.mesh_path
+            if isinstance(self.mesh_path, pathlib.Path)
+            else pathlib.Path(self.mesh_path)
+        )
+
         if not mesh_path.is_file():
             raise FileNotFoundError(f"Mesh file not found at {self.mesh_path}")
 

--- a/src/rod/builder/primitives.py
+++ b/src/rod/builder/primitives.py
@@ -65,6 +65,7 @@ class CylinderBuilder(PrimitiveBuilder):
 class MeshBuilder(PrimitiveBuilder):
     mesh_path: str | pathlib.Path
     scale: NDArray
+    is_empty: bool = False
 
     def __post_init__(self) -> None:
         """
@@ -78,6 +79,7 @@ class MeshBuilder(PrimitiveBuilder):
 
         if os.stat(self.mesh_path).st_size == 0:
             # File is empty
+            self.is_empty = True
             rod.logging.warning(f"Meshbuilder instantiated with empty mesh file {self.mesh_path}")
 
         if isinstance(self.mesh_path, str):

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -74,17 +74,3 @@ def test_builder_creation_custom_mesh():
     ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
 
     assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
-
-
-def test_builder_empty_mesh():
-    with tempfile.TemporaryDirectory() as tmp:
-        with tempfile.NamedTemporaryFile(suffix=".stl", dir=tmp, delete=False) as fp:
-
-            builder = MeshBuilder(
-                name="test_mesh",
-                mesh_path=fp.name,
-                mass=1.0,
-                scale=np.array([1.0, 1.0, 1.0]),
-            )
-
-    assert builder.is_empty == True, f"builder.is_empty is {builder.is_empty} != True"

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -5,7 +5,6 @@ import trimesh
 
 from rod.builder.primitives import MeshBuilder
 
-
 def test_builder_creation():
 
     # Create a mesh of a box primitive.
@@ -74,3 +73,16 @@ def test_builder_creation_custom_mesh():
     ), f"{builder.mesh.moment_inertia} != {mesh.moment_inertia}"
 
     assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
+
+def test_builder_empty_mesh():
+    with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".stl", dir=tmp, delete=False) as fp:
+            
+            builder = MeshBuilder(
+                name="test_mesh",
+                mesh_path=fp.name,
+                mass=1.0,
+                scale=np.array([1.0, 1.0, 1.0]),
+            )
+
+    assert builder.is_empty == True, f"builder.is_empty is {builder.is_empty} != True"

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -5,6 +5,7 @@ import trimesh
 
 from rod.builder.primitives import MeshBuilder
 
+
 def test_builder_creation():
 
     # Create a mesh of a box primitive.
@@ -74,10 +75,11 @@ def test_builder_creation_custom_mesh():
 
     assert builder.mesh.volume == mesh.volume, f"{builder.mesh.volume} != {mesh.volume}"
 
+
 def test_builder_empty_mesh():
     with tempfile.TemporaryDirectory() as tmp:
         with tempfile.NamedTemporaryFile(suffix=".stl", dir=tmp, delete=False) as fp:
-            
+
             builder = MeshBuilder(
                 name="test_mesh",
                 mesh_path=fp.name,


### PR DESCRIPTION
With this pull request, I suggest to move the mesh loading part inside of a context manager to ensure that the file is properly closed, but most importantly to avoid a bug from trimesh where a string can be passed to `trimesh.load_mesh`, but internally it requires a file-like object. This way, the mesh is instantly loaded using a file object.
Also, I added a logging warning from `MeshBuilder` when an empty mesh is loaded.