### PR TITLE
Update `MeshBuilder` class

### DIFF
--- a/src/rod/builder/primitive_builder.py
+++ b/src/rod/builder/primitive_builder.py
@@ -12,8 +12,9 @@ from rod import logging
 
 @dataclasses.dataclass
 class PrimitiveBuilder(abc.ABC):
-    name: str
-    mass: float
+
+    name: str = dataclasses.field(kw_only=True)
+    mass: float = dataclasses.field(kw_only=True)
 
     element: rod.Model | rod.Link | rod.Inertial | rod.Collision | rod.Visual = (
         dataclasses.field(

--- a/tests/test_meshbuilder.py
+++ b/tests/test_meshbuilder.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import numpy as np
+import pytest
 import trimesh
 
 from rod.builder.primitives import MeshBuilder
@@ -20,10 +21,17 @@ def test_builder_creation():
 
             builder = MeshBuilder(
                 name="test_mesh",
-                mesh_path=fp.name,
+                mesh_uri=fp.name,
                 mass=1.0,
                 scale=np.array([1.0, 1.0, 1.0]),
             )
+
+    # Check that the builder can build a correct link.
+    # Note that the URI is not valid since it's a temporary file.
+    link = builder.build_link().add_inertial().add_visual().add_collision().build()
+    assert link.collision is not None
+    assert link.collision.geometry.mesh is not None
+    assert link.collision.geometry.mesh.scale == pytest.approx([1, 1, 1])
 
     assert (
         builder.mesh.vertices.shape == mesh.vertices.shape
@@ -56,7 +64,7 @@ def test_builder_creation_custom_mesh():
 
             builder = MeshBuilder(
                 name="test_mesh",
-                mesh_path=fp.name,
+                mesh_uri=fp.name,
                 mass=1.0,
                 scale=np.array([1.0, 1.0, 1.0]),
             )


### PR DESCRIPTION
This PR enhances the mesh support introduced in #33. In particular:

- The path to the mesh can now be an URI. Storing the URI instead of the absolute path is important if the builder is used to create a model programmatically that can be used on different machines. Now the URI is resolved only when the trimesh object is created, but it's stored as unresolved so that it can be serialized in a SDF/URDF model as URI.
- Allows to pass the mass and inertia tensor to the builder. This information stored in mesh files is not always what's used for the inertial properties, and not always valid.

cc @lorycontixd can you please try if the changes break your pipeline? For sure you have to update `mesh_path` with `mesh_uri`. Sorry for this change, I overlooked this use-case in your original contribution.