### PR TITLE
Pin Ubuntu Jammy in CI/CD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -66,7 +66,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          # This runner can be updated to ubuntu > jammy as soon as we bump
+          # the minimum libsdformat to v14.
+          - ubuntu-22.04
           - macos-latest
           - windows-latest
         type:


### PR DESCRIPTION
Overnight, GitHub Actions updated the default `ubuntu-latest` to `ubuntu-22.04`. It's not a big deal for this project, but the OSRF repository does not longer ships `libsdformat13`.

Since this is the oldest version we want to support, it makes sense to keep testing our code against it. In this PR, I pin `ubuntu-22.04` in the runner so that we keep using `libsdformat13`.