### PR TITLE
Update CI/CD workflow to interface with PyPI as Trusted Publisher

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -165,6 +165,8 @@ jobs:
     name: Publish to PyPI
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+        id-token: write
 
     steps:
 
@@ -184,6 +186,4 @@ jobs:
            (github.event_name == 'release' && github.event.action == 'published'))
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
           skip_existing: true


### PR DESCRIPTION
Similar to https://github.com/ami-iit/jaxsim/pull/174 . I added the `ci_cd.yml` action as Trusted Publisher on PyPI side, so I think we can then merge this PR and remove the `PYPI_TOKEN` from the repo secrets (that I guess is @diegoferigo's one).