### PR TITLE
Redirect `stderr` to pipe instead of STDOUT

### DIFF
--- a/src/rod/utils/gazebo.py
+++ b/src/rod/utils/gazebo.py
@@ -106,8 +106,7 @@ class GazeboHelper:
                 cp = subprocess.run(
                     [str(gazebo_executable), "sdf", "-p", fp.name],
                     text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    capture_output=True,
                     check=True,
                 )
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Redirecting `stderr` to a pipe allows for better error handling and separation of standard output and error messages.

Fixes #52