### PR TITLE
Add Pixi support and configuration files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# LFS
+pixi.lock filter=lfs diff=lfs merge=lfs -text
+
 # SCM syntax highlighting
 pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # IDE
 .idea
+
+# pixi environments
+.pixi
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ This will automatically install `sdformat` and `gz-tools`.
 </details>
 
 <details>
+<summary>Using pixi</summary>
+
+[`pixi`](https://pixi.sh) definetly provides the quickest way to start using ROD. You can run the tests by executing:
+
+```bash
+pixi run test
+```
+
+or install the default dependencies with:
+
+```bash
+pixi install
+```
+
+check out the [pyproject.toml](./pyproject.toml) file for the list of all available features and read the [`pixi`](https://pixi.sh) documentation for more information.
+
+</details>
+
+
+<details>
 <summary>Using pip</summary>
 
 You can install ROD from PyPI with [`pypa/pip`][pip], preferably in a [virtual environment][venv]:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad5c217ec910b6fb75d18e454db364169b66ecc039e8aa706a75ad269661e1df
+size 100593

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,4 +196,5 @@ pptree = { features = ["pptree"], solve-group = "default" }
 style = { features = ["style"], solve-group = "default" }
 testing = { features = ["testing"], solve-group = "default" }
 
-[tool.pixi.tasks]
+[tool.pixi.feature.testing.tasks]
+test = "pytest -vv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,3 +164,19 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in all `__init__.py` files
 "__init__.py" = ["F401", "F821"]
+
+[tool.pixi.project]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tool.pixi.pypi-dependencies]
+rod = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+all = { features = ["all", "style", "pptree", "testing"], solve-group = "default" }
+pptree = { features = ["pptree"], solve-group = "default" }
+style = { features = ["style"], solve-group = "default" }
+testing = { features = ["testing"], solve-group = "default" }
+
+[tool.pixi.tasks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,26 @@ ignore = [
 # Ignore `E402` (import violations) in all `__init__.py` files
 "__init__.py" = ["F401", "F821"]
 
+
+# ==================
+# Pixi configuration
+# ==================
+
 [tool.pixi.project]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
+
+[tool.pixi.dependencies]
+resolve-robotics-uri-py = "*"
+trimesh = "*"
+xmltodict = "*"
+coloredlogs = "*"
+mashumaro = "*"
+gz-tools2 = "*"
+libsdformat13 = "*"
+numpy = "*"
+scipy = "*"
+packaging = "*"
 
 [tool.pixi.pypi-dependencies]
 rod = { path = ".", editable = true }


### PR DESCRIPTION
This PR introduces support for Pixi by updating the `.gitignore`, adding dependencies in `pyproject.toml`, and configuring LFS for `pixi.lock`, including a test task for Pixi environments.