### PR TITLE
Cast `int` values to `float` when required

### DIFF
--- a/src/rod/sdf/element.py
+++ b/src/rod/sdf/element.py
@@ -41,6 +41,8 @@ class Element(mashumaro.mixins.dict.DataClassDictMixin, DataclassPrettyPrinter):
 
     @staticmethod
     def serialize_float(data: float) -> str:
+        if isinstance(data, int):
+            data = float(data)
         assert isinstance(data, float)
         return str(data)
 


### PR DESCRIPTION
This pull request includes a minor change to the `serialize_float` method in the `src/rod/sdf/element.py` file. The change ensures that if the input data is an integer, it is converted to a float before being serialized.

* [`src/rod/sdf/element.py`](diffhunk://#diff-37340470d066c0eeb2f42fb1bd407f15d354c70e790f613000f0a0302774610dR44-R45): Added a check to convert integer input to float in the `serialize_float` method.