### PR TITLE
Add typechecking on `relative_to` argument of `rod.Pose`

### DIFF
--- a/src/rod/utils/resolve_frames.py
+++ b/src/rod/utils/resolve_frames.py
@@ -16,11 +16,13 @@ def update_element_with_pose(
 
     # If there are multiple defaults to detect (e.g. __model__ and <model_name>),
     # we select the first entry of the list as real default
-    default_relative_to = (
-        [default_relative_to]
-        if isinstance(default_relative_to, str)
-        else default_relative_to
-    )
+    if isinstance(default_relative_to, str):
+        default_relative_to = [default_relative_to]
+    elif not (
+        isinstance(default_relative_to, list)
+        and all(isinstance(x, str) for x in default_relative_to)
+    ):
+        raise TypeError("`default_relative_to must` be a string or a list of strings")
 
     if len(default_relative_to) < 1:
         raise ValueError(default_relative_to)


### PR DESCRIPTION
This pull request adds a validation of the `default_relative_to` parameter.

* [`src/rod/utils/resolve_frames.py`](diffhunk://#diff-b4dfbc45c918739b288531a69cce94b42cbafa9117eeb0ab3d1c974bbdf641dbL19-R22): Modified the `update_element_with_pose` function to validate that `default_relative_to` is either a string or a list of strings. If it is a string, it is converted to a list. If it is not a string or a list of strings, a `TypeError` is raised.

This prevents cases in which the second argument of `rod.Pose` is passed as RPY coordinates, which made `relative_to` a list of floats.

```python
# Signature of rod.Pose
inspect.signature(rod.Pose)
# >>> <Signature (pose: 'list[float]' = None, relative_to: 'str | None' = None, degrees: 'bool | None' = None, rotation_format: 'str | None' = None) -> None>

# Erroneous usage
rod.Pose([0.2, 0, base_height / 2], [0, 0, 0])
```

C.C. @xela-95 