### PR TITLE
Update excluded bots from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
Similarly to https://github.com/ami-iit/jaxsim/pull/461, this PR updates bots name to be excluded from release notes